### PR TITLE
Fix to UsrPorts and UsrSrc target variable

### DIFF
--- a/lib/freebsd.sh
+++ b/lib/freebsd.sh
@@ -315,7 +315,7 @@ _freebsd_install_usr_src ( ) {
 }
 
 freebsd_install_usr_src ( ) {
-    _freebsd_install_usr_src ${UFS_MOUNT}
+    _freebsd_install_usr_src $1
 }
 
 # freebsd_install_usr_ports:  Download and install
@@ -332,7 +332,7 @@ _freebsd_install_usr_ports ( ) {
 }
 
 freebsd_install_usr_ports ( ) {
-    _freebsd_install_usr_ports ${UFS_MOUNT}
+    _freebsd_install_usr_ports $1
 }
 
 


### PR DESCRIPTION
When selecting config option UsrPorts and UsrSrc it keeps on writing it the content to / which I am pretty sure is not the intention.

Changed the ${UFS_MOUNT} to $1
