### PR TITLE
Honor RPI_UBOOT_SRC in config.sh.

### DIFF
--- a/board/RaspberryPi/setup.sh
+++ b/board/RaspberryPi/setup.sh
@@ -1,5 +1,9 @@
 KERNCONF=RPI-B
-RPI_UBOOT_SRC=${TOPDIR}/u-boot-rpi
+if [ "X${RPI_UBOOT_SRC}" != "X" ]; then
+	# Already set in config.sh
+else
+	RPI_UBOOT_SRC=${TOPDIR}/u-boot-rpi
+fi
 RPI_GPU_MEM=32
 IMAGE_SIZE=$((1000 * 1000 * 1000)) # 1 GB default
 TARGET_ARCH=arm


### PR DESCRIPTION
If RPI_UBOOT_SRC is set in config.sh, it is seemingly overridden after kernel build.
