### PR TITLE
Improve OBJDIR detection.

### DIFF
--- a/lib/freebsd.sh
+++ b/lib/freebsd.sh
@@ -78,19 +78,15 @@ freebsd_objdir ( ) {
     # idiom to copy files out of the obj tree without actually
     # knowing where it is:
     #     "cd src-dir-location; make DESTDIR=XYZ install" 
-    FREEBSD_OBJDIR=${MAKEOBJDIRPREFIX}/$TARGET_ARCH.$TARGET_ARCH${FREEBSD_SRC}
     
     if [ "$FREEBSD_MAJOR_VERSION" -eq "8" ]
     then
         FREEBSD_OBJDIR=${MAKEOBJDIRPREFIX}/$TARGET_ARCH${FREEBSD_SRC}
     fi
-    if [ "$FREEBSD_MAJOR_VERSION" -eq "9" ]
+    if [ "$FREEBSD_MAJOR_VERSION" -ge "9" ]
     then
-        FREEBSD_OBJDIR=${MAKEOBJDIRPREFIX}/$TARGET_ARCH.$TARGET_ARCH${FREEBSD_SRC}
-    fi
-    if [ "$FREEBSD_MAJOR_VERSION" -eq "10" ]
-    then
-        FREEBSD_OBJDIR=${MAKEOBJDIRPREFIX}/$TARGET_ARCH.$TARGET_ARCH${FREEBSD_SRC}
+        buildenv=`make -C $FREEBSD_SRC TARGET_ARCH=$TARGET_ARCH buildenvvars`
+        FREEBSD_OBJDIR=`eval $buildenv printenv MAKEOBJDIRPREFIX`${FREEBSD_SRC}
     fi
     echo "Object files are at: "${FREEBSD_OBJDIR}
 }


### PR DESCRIPTION
Uses buildenv to grab the real obj prefix and concatenates
the source directory. Only tested on 9+ so I left the 9 case
in place.
