### PR TITLE
updates to allow putting dtb file on UFS partition.

### DIFF
--- a/board/Wandboard/files/uEnv.txt
+++ b/board/Wandboard/files/uEnv.txt
@@ -1,2 +1,2 @@
-uenvcmd=fatload mmc 0:1 0x11000000 wandboard-quad.dtb;fatload mmc 0:1 88000000 ubldr;bootelf 88000000;
+uenvcmd=setenv fdt_file wandboard-quad.dtb;fatload mmc 0:1 88000000 ubldr;bootelf 88000000;
 

--- a/board/Wandboard/setup.sh
+++ b/board/Wandboard/setup.sh
@@ -69,14 +69,24 @@ wandboard_install_uenvtxt(){
 strategy_add $PHASE_BOOT_INSTALL wandboard_install_uenvtxt
 
 #
-# DTS
+# DTS to FAT file system
 #
-wandboard_install_dts(){
-    echo "Installing DTS"
+wandboard_install_dts_fat(){
+    echo "Installing DTS to FAT"
     freebsd_install_fdt arm/wandboard-quad.dts wandboard-quad.dts
     freebsd_install_fdt arm/wandboard-quad.dts wandboard-quad.dtb
 }
-strategy_add $PHASE_BOOT_INSTALL wandboard_install_dts
+#strategy_add $PHASE_BOOT_INSTALL wandboard_install_dts_fat
+
+#
+# DTS to UFS file system. This is in PHASE_FREEBSD_BOARD_POST_INSTALL b/c it needs to happen *after* the kernel install
+#
+wandboard_install_dts_ufs(){
+    echo "Installing DTS to UFS"
+    freebsd_install_fdt arm/wandboard-quad.dts boot/kernel/wandboard-quad.dts
+    freebsd_install_fdt arm/wandboard-quad.dts boot/kernel/wandboard-quad.dtb
+}
+strategy_add $PHASE_FREEBSD_BOARD_POST_INSTALL wandboard_install_dts_ufs
 
 #
 # kernel

--- a/board/Wandboard/util/mount_image.sh
+++ b/board/Wandboard/util/mount_image.sh
@@ -1,8 +1,0 @@
-IMAGE=`ls ../../../work/*.img`
-mdconfig -a -t vnode -f ${IMAGE} -u 0
-mkdir -p /tmp/imagemount_root
-mkdir -p /tmp/imagemount_freebsd
-mount_msdosfs /dev/md0s1 /tmp/imagemount_root
-mount /dev/md0s2a /tmp/imagemount_freebsd
-
-

--- a/board/Wandboard/util/unmount_image.sh
+++ b/board/Wandboard/util/unmount_image.sh
@@ -1,4 +1,0 @@
-umount /tmp/imagemount_root
-umount /tmp/imagemount_freebsd
-mdconfig -d -u 0
-

--- a/lib/strategy.sh
+++ b/lib/strategy.sh
@@ -76,6 +76,8 @@ PHASE_FREEBSD_START=700
 PHASE_FREEBSD_INSTALLWORLD_LWW=711
 # "Board" is reserved for board definitions
 PHASE_FREEBSD_BOARD_INSTALL=720
+# "Board post-install is for configuration that happens in the board, after the board install"
+PHASE_FREEBSD_BOARD_POST_INSTALL=721
 # "Option" is reserved for options
 PHASE_FREEBSD_OPTION_INSTALL=760
 # "User" is reserved for user customization and should not be used

--- a/util/mount_image.sh
+++ b/util/mount_image.sh
@@ -1,0 +1,8 @@
+IMAGE=`ls work/*.img`
+mdconfig -a -t vnode -f ${IMAGE} -u 0
+mkdir -p /tmp/crochet_root
+mkdir -p /tmp/crochet_freebsd
+mount_msdosfs /dev/md0s1 /tmp/crochet_root
+mount /dev/md0s2a /tmp/crochet_freebsd
+
+

--- a/util/unmount_image.sh
+++ b/util/unmount_image.sh
@@ -1,0 +1,4 @@
+umount /tmp/crochet_root
+umount /tmp/crochet_freebsd
+mdconfig -d -u 0
+


### PR DESCRIPTION
uEnv.txt updated to pass the name of the dtb file to ubldr
added a PHASE to the strategies, called PHASE_FREEBSD_BOARD_POST_INSTALL.    This is necessary to ensure that the kernel is installed before the dtb file, or the kernel install will overwrite the dtb file
