### PR TITLE
 Add the capability to specify an alternate uboot location.

### DIFF
--- a/board/BeagleBone/setup.sh
+++ b/board/BeagleBone/setup.sh
@@ -18,6 +18,14 @@ strategy_add $PHASE_PARTITION_LWW beaglebone_partition_image
 #
 # BeagleBone uses U-Boot.
 #
+uboot_eabi_port_version ( ) {
+    pkg query '%n-%v' u-boot-beaglebone-eabi
+}
+
+uboot_eabi_port_location ( ) {
+    pkg query '%p' u-boot-beaglebone-eabi
+}
+
 beaglebone_check_uboot ( ) {
     if [ -n "${BEAGLEBONE_UBOOT}" ]; then
 	echo "Using U-Boot from location: ${BEAGLEBONE_UBOOT}"

--- a/lib/uboot.sh
+++ b/lib/uboot.sh
@@ -171,16 +171,6 @@ uboot_build ( ) (
     touch $1/_.uboot.built
 )
 
-
-uboot_eabi_port_version ( ) {
-    pkg query '%n-%v' u-boot-beaglebone-eabi
-}
-
-uboot_eabi_port_location ( ) {
-    pkg query '%p' u-boot-beaglebone-eabi
-}
-
-
 # uboot_version_from_dir
 #
 # $1: base dir of U-Boot sources


### PR DESCRIPTION
 Add the capability to specify an alternate uboot location.
If the u-boot-beaglebone-eabi port is installed, used this.
 Otherwise use the source and compile
