### PR TITLE
Removal of OBJDIR from Soekris

### DIFF
--- a/board/Soekris/setup.sh
+++ b/board/Soekris/setup.sh
@@ -2,6 +2,8 @@ TARGET_ARCH=i386
 KERNCONF=SOEKRIS
 IMAGE_SIZE=$((1024 * 1000 * 1000))
 
+. ${LIBDIR}/i386.sh
+
 # copy the build config
 soekris_copy_buildconfig ( ) {
     KERNEL_CONFIG_FILE="SOEKRIS${FREEBSD_MAJOR_VERSION}"
@@ -9,30 +11,6 @@ soekris_copy_buildconfig ( ) {
     cp ${BOARDDIR}/conf/${KERNEL_CONFIG_FILE} ${FREEBSD_SRC}/sys/i386/conf/${KERNCONF}
 }
 strategy_add $PHASE_POST_CONFIG soekris_copy_buildconfig
-
-# create a MBR disk with a single UFS partition
-# based on instructions here: http://www.wonkity.com/~wblock/docs/html/disksetup.html
-#
-soekris_partition_image ( ) {
-    # basic setup
-    disk_partition_mbr
-    disk_ufs_create
-
-    # boot loader
-    echo "Installing bootblocks"
-    # TODO: This is broken; should use 'make install' to copy
-    # bootfiles to workdir, then install to disk image from there.
-    BOOTFILES=${FREEBSD_OBJDIR}/sys/boot/i386
-    echo "Boot files are at: "${BOOTFILES}
-    gpart bootcode -b ${BOOTFILES}/mbr/mbr ${DISK_MD} || exit 1
-    gpart set -a active -i 1 ${DISK_MD} || exit 1
-    bsdlabel -B -b ${BOOTFILES}/boot2/boot `disk_ufs_partition` || exit 1
-
-    #show the disk
-    gpart show ${DISK_MD}
-}
-
-strategy_add $PHASE_PARTITION_LWW soekris_partition_image
 
 # Kernel installs in UFS partition
 strategy_add $PHASE_FREEBSD_BOARD_INSTALL board_default_installkernel .

--- a/board/VMWareGuest/setup.sh
+++ b/board/VMWareGuest/setup.sh
@@ -2,98 +2,16 @@ TARGET_ARCH=i386
 KERNCONF=GENERIC
 IMAGE_SIZE=$((800 * 1000 * 1000))
 
+. ${LIBDIR}/i386.sh
+
 #
 # Builds a basic i386 image.
 #
 
-# Clean out any old i386 boot bits.
-rm -rf ${WORKDIR}/boot
-mkdir -p ${WORKDIR}/boot/defaults
-
 # Value in MB.
 VMWARE_MEMSIZE=1024
 
-#
-# Note that the 'build' functions here all do a fake 'install' to
-# ${WORKDIR}/boot so we can copy single files to the final image
-# without having to hardcode deep paths into the FreeBSD source or
-# object tree.
-#
-
-generic_i386_build_mbr ( ) {
-    echo "Building MBR"
-    cd ${FREEBSD_SRC}
-    buildenv=`make TARGET_ARCH=${TARGET_ARCH} buildenvvars`
-    cd sys/boot/i386/mbr
-    if eval $buildenv make > ${WORKDIR}/_.i386.mbr.log 2>&1
-    then
-	true
-    else
-	echo "Failed to build MBR:"
-	tail ${WORKDIR}/_.i386.mbr.log
-	exit 1
-    fi
-    eval $buildenv make DESTDIR=${WORKDIR} install || exit 1
-}
-strategy_add $PHASE_BUILD_OTHER generic_i386_build_mbr
-
-generic_i386_build_boot2 ( ) {
-    echo "Building Boot2"
-    cd ${FREEBSD_SRC}
-    buildenv=`make TARGET_ARCH=${TARGET_ARCH} buildenvvars`
-    cd sys/boot/i386/boot2
-    if eval $buildenv make > ${WORKDIR}/_.i386.boot2.log 2>&1
-    then
-	true
-    else
-	echo "Failed to build boot2:"
-	tail ${WORKDIR}/_.i386.boot2.log
-	exit 1
-    fi
-    eval $buildenv make DESTDIR=${WORKDIR} install || exit 1
-}
-strategy_add $PHASE_BUILD_OTHER generic_i386_build_boot2
-
-generic_i386_build_loader ( ) {
-    echo "Building Loader"
-    cd ${FREEBSD_SRC}
-    buildenv=`make TARGET_ARCH=${TARGET_ARCH} buildenvvars`
-    cd sys/boot/i386/loader
-    if eval $buildenv make > ${WORKDIR}/_.i386_loader_build.log 2>&1
-    then
-	true
-    else
-	echo "Failed to build i386 loader:"
-	tail ${WORKDIR}/_.i386_loader_build.log
-	exit 1
-    fi
-    if eval $buildenv make DESTDIR=${WORKDIR} NO_MAN=t install > ${WORKDIR}/_.i386_loader_install.log 2>&1
-    then
-	true
-    else
-	echo "Failed to copy i386 loader into workdir:"
-	tail ${WORKDIR}/_.i386_loader_install.log
-	exit 1
-    fi
-
-}
-strategy_add $PHASE_BUILD_OTHER generic_i386_build_loader
-
-# Even though there's only the default partition, we have
-# to do extra work here to set all the boot bits.
-# DISK_MD is set by the helper functions in lib/disk.sh.
-generic_i386_partition_image ( ) {
-    disk_partition_mbr
-    disk_ufs_create
-    echo "Installing bootblocks"
-    gpart bootcode -b ${WORKDIR}/boot/mbr ${DISK_MD} || exit 1
-    gpart set -a active -i 1 ${DISK_MD} || exit 1
-    bsdlabel -B -b ${WORKDIR}/boot/boot `disk_ufs_slice` || exit 1
-}
-strategy_add $PHASE_PARTITION_LWW generic_i386_partition_image
-
 # Don't need custom mount since the default works for us.
-
 generic_i386_board_install ( ) {
     # I386 images expect a copy of all the boot bits in /boot
     echo "Installing loader(8)"

--- a/lib/i386.sh
+++ b/lib/i386.sh
@@ -1,0 +1,84 @@
+
+# Clean out any old i386 boot bits.
+rm -rf ${WORKDIR}/boot
+mkdir -p ${WORKDIR}/boot/defaults
+
+#
+# Note that the 'build' functions here all do a fake 'install' to
+# ${WORKDIR}/boot so we can copy single files to the final image
+# without having to hardcode deep paths into the FreeBSD source or
+# object tree.
+#
+generic_i386_build_mbr ( ) {
+    echo "Building MBR"
+    cd ${FREEBSD_SRC}
+    buildenv=`make -C ${FREEBSD_SRC} TARGET_ARCH=${TARGET_ARCH} buildenvvars`
+    cd sys/boot/i386/mbr
+    if eval ${buildenv} make > ${WORKDIR}/_.i386.mbr.log 2>&1
+    then
+    true
+    else
+    echo "Failed to build MBR:"
+    tail ${WORKDIR}/_.i386.mbr.log
+    exit 1
+    fi
+    eval ${buildenv} make DESTDIR=${WORKDIR} install || exit 1
+}
+strategy_add $PHASE_BUILD_OTHER generic_i386_build_mbr
+
+generic_i386_build_boot2 ( ) {
+    echo "Building Boot2"
+    cd ${FREEBSD_SRC}
+        buildenv=`make -C ${FREEBSD_SRC} TARGET_ARCH=${TARGET_ARCH} buildenvvars`
+    cd sys/boot/i386/boot2
+    if eval ${buildenv} make > ${WORKDIR}/_.i386.boot2.log 2>&1
+    then
+    true
+    else
+    echo "Failed to build boot2:"
+    tail ${WORKDIR}/_.i386.boot2.log
+    exit 1
+    fi
+    eval ${buildenv} make DESTDIR=${WORKDIR} install || exit 1
+}
+strategy_add $PHASE_BUILD_OTHER generic_i386_build_boot2
+
+generic_i386_build_loader ( ) {
+    echo "Building Loader"
+    cd ${FREEBSD_SRC}
+    export MAKESYSPATH=${FREEBSD_SRC}/share/mk
+    buildenv=`make TARGET_ARCH=${TARGET_ARCH} buildenvvars`
+    cd sys/boot/i386/loader
+    if eval ${buildenv} make > ${WORKDIR}/_.i386_loader_build.log 2>&1
+    then
+    true
+    else
+    echo "Failed to build i386 loader:"
+    tail ${WORKDIR}/_.i386_loader_build.log
+    exit 1
+    fi
+    if eval ${buildenv} make DESTDIR=${WORKDIR} NO_MAN=t install > ${WORKDIR}/_.i386_loader_install.log 2>&1
+    then
+    true
+    else
+    echo "Failed to copy i386 loader into WORKDIR:"
+    tail ${WORKDIR}/_.i386_loader_install.log
+    exit 1
+    fi
+
+}
+strategy_add $PHASE_BUILD_OTHER generic_i386_build_loader
+
+# Even though there's only the default partition, we have
+# to do extra work here to set all the boot bits.
+# DISK_MD is set by the helper functions in lib/disk.sh.
+generic_i386_partition_image ( ) {
+    disk_partition_mbr
+    disk_ufs_create
+    echo "Installing bootblocks"
+    gpart bootcode -b ${WORKDIR}/boot/mbr ${DISK_MD} || exit 1
+    gpart set -a active -i 1 ${DISK_MD} || exit 1
+    bsdlabel -B -b ${WORKDIR}/boot/boot `disk_ufs_slice` || exit 1
+}
+strategy_add $PHASE_PARTITION_LWW generic_i386_partition_image
+


### PR DESCRIPTION
Removed the OBJDIR hack from Soekris
Moved the generic_i386_\* methods to i386.sh so that they could be shared by both VMWareGuest and Soekris
