### PR TITLE
Add SRCCONF and __MAKE_CONF to ubldr environment

### DIFF
--- a/lib/freebsd.sh
+++ b/lib/freebsd.sh
@@ -312,6 +312,7 @@ freebsd_ubldr_build ( ) {
     LOGFILE=${UBLDR_DIR}/_.ubldr.${CONF}.build.log
     ubldr_makefiles=`pwd`/share/mk
     buildenv=`make TARGET_ARCH=$TARGET_ARCH buildenvvars`
+    buildenv="$buildenv SRCCONF=${SRCCONF} __MAKE_CONF=${__MAKE_CONF}"
 
     mkdir -p ${UBLDR_DIR}
 


### PR DESCRIPTION
This fixes build when world has libraries that are built with different options than in the
default src.conf (like nandfs, etc).