### PR TITLE
Give a proper path when installing ubldr

### DIFF
--- a/lib/freebsd.sh
+++ b/lib/freebsd.sh
@@ -372,7 +372,11 @@ freebsd_ubldr_copy ( ) {
 }
 
 freebsd_ubldr_copy_ubldr ( ) {
-    echo "Installing ubldr in $1"
+    if [ $1 = "." ]; then
+	echo "Installing ubldr in ${PWD}"
+    else
+	echo "Installing ubldr in $1"
+    fi
     CONF=${TARGET_ARCH}-${KERNCONF}
     cp ${WORKDIR}/ubldr-${CONF}/boot/ubldr* $1 || exit 1
 }


### PR DESCRIPTION
This makes the log look more like the rest of the messages.. i.e.

This:
```Installing ubldr in /home/brd/crochet/work/_.mount.boot```

Instead of:
```Installing ubldr in .```