### PR TITLE
Use armv6hf target arch by defaut for the raspberry Pi

### DIFF
--- a/board/RaspberryPi/setup.sh
+++ b/board/RaspberryPi/setup.sh
@@ -4,7 +4,7 @@ RPI_UBOOT_BIN="u-boot.img"
 RPI_FIRMWARE_SRC=/usr/local/share/u-boot/${RPI_UBOOT_PORT}
 RPI_GPU_MEM=32
 IMAGE_SIZE=$((1000 * 1000 * 1000)) # 1 GB default
-TARGET_ARCH=armv6
+TARGET_ARCH=armv6hf # compile to target the hard float ABI
 
 #
 # Because of the complexity of the Raspberry Pi boot


### PR DESCRIPTION
According to this page https://wiki.freebsd.org/FreeBSD/arm/crossbuild armv6hf is one the targets archs available to cross-compile FreeBSD:
ARMv6 and ARMv7 systems with native hardware floating point.
The raspberry Pi model A, B, B+ has a hardware FPU.