### PR TITLE
Change default terminal to vt100 for RPi boards

### DIFF
--- a/board/RaspberryPi/overlay/etc/ttys
+++ b/board/RaspberryPi/overlay/etc/ttys
@@ -2,4 +2,4 @@ ttyv0	"/usr/libexec/getty Pc"		xterm	on  secure
 ttyv1	"/usr/libexec/getty Pc"		xterm	on  secure
 ttyv2	"/usr/libexec/getty Pc"		xterm	on  secure
 ttyv3	"/usr/libexec/getty Pc"		xterm	on  secure
-ttyu0	"/usr/libexec/getty 3wire.115200"	dialup	on secure
+ttyu0	"/usr/libexec/getty 3wire.115200"	vt100	on secure

--- a/board/RaspberryPi2/overlay/etc/ttys
+++ b/board/RaspberryPi2/overlay/etc/ttys
@@ -2,4 +2,4 @@ ttyv0	"/usr/libexec/getty Pc"		xterm	on  secure
 ttyv1	"/usr/libexec/getty Pc"		xterm	on  secure
 ttyv2	"/usr/libexec/getty Pc"		xterm	on  secure
 ttyv3	"/usr/libexec/getty Pc"		xterm	on  secure
-ttyu0	"/usr/libexec/getty 3wire.115200"	dialup	on secure
+ttyu0	"/usr/libexec/getty 3wire.115200"	vt100	on secure


### PR DESCRIPTION
When using `dialup` terminal type, some applications that "draw" stuff on the screen don't work like: `edit`, `nano`, `tmux`, or any `ncurses` application. This is fixed by changing the terminal type to `vt100` in `/etc/ttys` so those types of applications may run "out of the box."