### PR TITLE
Fix ${FREEBSD_OBJDIR}

### DIFF
--- a/lib/disk.sh
+++ b/lib/disk.sh
@@ -429,6 +429,13 @@ disk_ufs_mount ( ) {
 
 
 #
+disk_efi_create ( ) {
+    NEW_EFI_PARTITION=`gpart add -t efi -s 800K ${DISK_MD} | sed -e 's/ .*//'` || exit 1
+    dd if=${FREEBSD_OBJDIR}/sys/boot/efi/boot1/boot1.efifat of=${NEW_EFI_PARTITION}
+}
+
+
+#
 # $1: mount point
 # $2: absolute index of partition to mount
 disk_mount ( ) {

--- a/lib/freebsd.sh
+++ b/lib/freebsd.sh
@@ -95,12 +95,13 @@ freebsd_objdir ( ) {
     
     if [ "$FREEBSD_MAJOR_VERSION" -eq "8" ]
     then
-        FREEBSD_OBJDIR=${MAKEOBJDIRPREFIX}/$TARGET_ARCH${FREEBSD_SRC}
+        FREEBSD_OBJDIR=${MAKEOBJDIRPREFIX}/${TARGET_ARCH}${FREEBSD_SRC}
     fi
     if [ "$FREEBSD_MAJOR_VERSION" -ge "9" ]
     then
         buildenv=`make -C $FREEBSD_SRC TARGET_ARCH=$TARGET_ARCH buildenvvars`
-        FREEBSD_OBJDIR=`eval $buildenv printenv MAKEOBJDIRPREFIX`${FREEBSD_SRC}
+        FREEBSD_OBJDIR=`eval $buildenv printenv MAKEOBJDIRPREFIX`
+        FREEBSD_OBJDIR=${FREEBSD_OBJDIR}`realpath ${FREEBSD_SRC}`
     fi
     echo "Object files are at: "${FREEBSD_OBJDIR}
 }


### PR DESCRIPTION
This comes into play when /home is a symlink to /usr/home.  Otherwise
the path in /usr/obj/usr/home/${USER}/crochet path doesn't match.