### PR TITLE
Fixed an issue with missing trailing / of objdir variable.

### DIFF
--- a/board/Alix/setup.sh
+++ b/board/Alix/setup.sh
@@ -23,7 +23,7 @@ alix_partition_image ( ) {
         echo "Installing bootblocks"
 	# TODO: This is broken; should use 'make install' to copy
 	# bootfiles to workdir, then install to disk image from there.
-        BOOTFILES=${FREEBSD_OBJDIR}sys/boot/i386
+        BOOTFILES=${FREEBSD_OBJDIR}/sys/boot/i386
         echo "Boot files are at: "${BOOTFILES}
         gpart bootcode -b ${BOOTFILES}/mbr/mbr ${DISK_MD} || exit 1
         gpart set -a active -i 1 ${DISK_MD} || exit 1


### PR DESCRIPTION
Installing bootblocks
Boot files are at: /root/crochet-master/work/obj/i386.i386/usr/srcsys/boot/i386
gpart: /root/crochet-master/work/obj/i386.i386/usr/srcsys/boot/i386/mbr/mbr: No such file or directory