### PR TITLE
Corrected EFI partition and WORLDJOBS/KERNJOBS variable

### DIFF
--- a/lib/disk.sh
+++ b/lib/disk.sh
@@ -93,7 +93,7 @@ disk_count ( ) {
     fi
 }
 
-# 
+#
 # Get value for variable with the given name from the given disk
 # index, which is relative to the given type, or absolute if the type
 # is omitted or empty.
@@ -113,7 +113,7 @@ disk_get_var ( ) {
     fi
     ABSINDEX=$1
 
-    if [ -n "$TYPE" ]; then 
+    if [ -n "$TYPE" ]; then
 	ABSINDEX=`disk_absindex ${TYPE} ${1}`
     fi
     VARNAME=$2
@@ -122,7 +122,7 @@ disk_get_var ( ) {
 }
 
 
-# 
+#
 # Set variable with the given name to the given value for the given
 # disk index, which is relative to the given type, or absolute if the
 # type is omitted or empty.
@@ -143,7 +143,7 @@ disk_set_var ( ) {
     fi
     ABSINDEX=$1
 
-    if [ -n "$TYPE" ]; then 
+    if [ -n "$TYPE" ]; then
 	ABSINDEX=`disk_absindex ${TYPE} ${1}`
     fi
     VARNAME=$2
@@ -152,7 +152,7 @@ disk_set_var ( ) {
     setvar DISK_${ABSINDEX}_${VARNAME} ${VALUE}
 }
 
-# 
+#
 # Adjust disk counts and set post-creation per-disk info-tracking variables
 #
 # $1: Type (e.g., FAT, RESERVED, UFS)
@@ -165,7 +165,7 @@ disk_created_new ( ) {
 
     DISK_COUNT=$(( `disk_count` + 1 ))
     setvar DISK_${TYPE}_COUNT $(( `disk_count ${TYPE}` + 1 ))
-    
+
     ABSINDEX=`disk_count`
     RELINDEX=`disk_count ${TYPE}`
 
@@ -357,7 +357,7 @@ disk_ufs_slice ( ) {
 # $1: index of UFS partition
 disk_ufs_device ( ) {
     local INDEX=$1
-    disk_device UFS ${INDEX:-1} 
+    disk_device UFS ${INDEX:-1}
 }
 
 # $1: index of UFS partition
@@ -374,7 +374,7 @@ disk_ufs_create ( ) {
     local NEW_UFS_SLICE_NUMBER
     local NEW_UFS_PARTITION
     local NEW_UFS_DEVICE
-    
+
     if [ -n "$1" ]; then
 	SIZE_ARG="-s $1"
 	SIZE_DISPLAY=" $1"
@@ -418,7 +418,7 @@ disk_ufs_label ( ) {
 
     if [ -n "$UFS_LABEL" ]; then
 	UFS_DEVICE=`disk_ufs_device ${UFS_INDEX}`
-	echo "Labeling ${UFS_DEVICE} ${UFS_LABEL}" 
+	echo "Labeling ${UFS_DEVICE} ${UFS_LABEL}"
 	tunefs -L ${UFS_LABEL} ${UFS_DEVICE}
     fi
 }
@@ -436,7 +436,9 @@ disk_ufs_mount ( ) {
 #
 disk_efi_create ( ) {
     NEW_EFI_PARTITION=`gpart add -t efi -s 800K ${DISK_MD} | sed -e 's/ .*//'` || exit 1
-    dd if=${FREEBSD_OBJDIR}/sys/boot/efi/boot1/boot1.efifat of=${NEW_EFI_PARTITION}
+    NEW_EFI_DEVICE=/dev/${NEW_EFI_PARTITION}
+	echo "Writing EFI partition to ${NEW_EFI_DEVICE}"
+    dd if=${FREEBSD_OBJDIR}/sys/boot/efi/boot1/boot1.efifat of=${NEW_EFI_DEVICE}
 }
 
 

--- a/lib/freebsd.sh
+++ b/lib/freebsd.sh
@@ -28,17 +28,6 @@ FREEBSD_INSTALLKERNEL_BOARD_ARGS=""
 SRCCONF=/dev/null
 __MAKE_CONF=/dev/null
 
-if [ -z ${WORLDJOBS} ]; then
-	WORLDJOBS="-j $(sysctl -n hw.ncpu)"
-else
-	WORLDJOBS="-j${WORLDJOBS}"
-fi
-if [ -z ${KERNJOBS} ]; then
-	KERNJOBS="-j $(sysctl -n hw.ncpu)"
-else
-	KERNJOBS="-j${KERNJOBS}"
-fi
-
 freebsd_default_makeobjdirprefix ( ) {
     if [ -z "$MAKEOBJDIRPREFIX" ]; then
         MAKEOBJDIRPREFIX=${WORKDIR}/obj
@@ -91,8 +80,8 @@ freebsd_objdir ( ) {
     # really should not need this; we can instead use the following
     # idiom to copy files out of the obj tree without actually
     # knowing where it is:
-    #     "cd src-dir-location; make DESTDIR=XYZ install" 
-    
+    #     "cd src-dir-location; make DESTDIR=XYZ install"
+
     if [ "$FREEBSD_MAJOR_VERSION" -eq "8" ]
     then
         FREEBSD_OBJDIR=${MAKEOBJDIRPREFIX}/${TARGET_ARCH}${FREEBSD_SRC}
@@ -212,6 +201,11 @@ _freebsd_build ( ) {
 # $@: additional make arguments
 #
 freebsd_buildworld ( ) {
+if [ -z ${WORLDJOBS} ]; then
+	WORLDJOBS="-j $(sysctl -n hw.ncpu)"
+else
+	WORLDJOBS="-j${WORLDJOBS}"
+fi
     _FREEBSD_WORLD_ARGS="TARGET_ARCH=${TARGET_ARCH} SRCCONF=${SRCCONF} __MAKE_CONF=${__MAKE_CONF} ${FREEBSD_EXTRA_ARGS} ${FREEBSD_WORLD_EXTRA_ARGS} ${FREEBSD_WORLD_BOARD_ARGS}"
     if [ -n "${TARGET_CPUTYPE}" ]; then
         _FREEBSD_WORLD_ARGS="TARGET_CPUTYPE=${TARGET_CPUTYPE} ${_FREEBSD_WORLD_ARGS}"
@@ -230,6 +224,11 @@ freebsd_buildworld ( ) {
 # $@: arguments to make.
 #
 freebsd_buildkernel ( ) {
+if [ -z ${KERNJOBS} ]; then
+	KERNJOBS="-j $(sysctl -n hw.ncpu)"
+else
+	KERNJOBS="-j${KERNJOBS}"
+fi
     _FREEBSD_KERNEL_ARGS="TARGET_ARCH=${TARGET_ARCH} SRCCONF=${SRCCONF} __MAKE_CONF=${__MAKE_CONF} KERNCONF=${KERNCONF} ${FREEBSD_EXTRA_ARGS} ${FREEBSD_KERNEL_EXTRA_ARGS} ${FREEBSD_KERNEL_BOARD_ARGS}"
     if [ -n "${TARGET_CPUTYPE}" ]; then
         _FREEBSD_KERNEL_ARGS="TARGET_CPUTYPE=${TARGET_CPUTYPE} ${_FREEBSD_KERNEL_ARGS}"
@@ -551,5 +550,3 @@ freebsd_replicate ( ) {
     pax -r -w -p e -k . $2
     echo "Replication complete at "`date`
 }
-
-


### PR DESCRIPTION
Efi partition was written to a local file. Added "/dev/" to efi partition variable to make correct efi device.
Kern/worldjobs did not work when defined in config.sh. Variables where rewritten (to -jx) too early before they had been set by the config file, moved to build() functions.