### PR TITLE
Fix package init cleanup

### DIFF
--- a/option/PackageInit/setup.sh
+++ b/option/PackageInit/setup.sh
@@ -48,7 +48,7 @@ EOF
 }
 
 package_init_cleanup ( ) {
-	rm 	${BOARD_FREEBSD_MOUNTPOINT}/etc/pkg/tmp.conf
+	rm -f ${BOARD_FREEBSD_MOUNTPOINT}/etc/pkg/tmp.conf
 }
 
 # Only register the package init functions once.


### PR DESCRIPTION
`etc/pkg/tmp.conf` might be missing when using default FreeBSD package site