### PR TITLE
Force long filenames on FAT partition

### DIFF
--- a/lib/disk.sh
+++ b/lib/disk.sh
@@ -343,7 +343,7 @@ disk_fat_create ( ) {
 disk_fat_mount ( ) {
     echo "Mounting FAT partition ${2:-1} at $1"
     disk_prep_mountdir $1
-    mount_msdosfs `disk_fat_device $2` $1
+    mount_msdosfs -l `disk_fat_device $2` $1
     disk_record_mountdir $1
 }
 


### PR DESCRIPTION
Building a Raspberry Pi 3 image on FreeBSD 11.0-RELEASE-p8 the FAT partition created contains 8+3 all _UPPERCASE_ letters, rendering image unbootable.

By adding `-l` flag to `mount_msdosfs` command, it forced the long filenames.