### PR TITLE
rename sunxi-spl.bin to u-boot-sunxi-with-spl.bin on all Allwinner boards

### DIFF
--- a/board/BananaPi-M3/setup.sh
+++ b/board/BananaPi-M3/setup.sh
@@ -9,7 +9,7 @@ UBOOT_PATH="/usr/local/share/u-boot/${SUNXI_UBOOT}"
 
 allwinner_partition_image ( ) {
     echo "Installing U-Boot files"
-    dd if=${UBOOT_PATH}/sunxi-spl.bin of=/dev/${DISK_MD} bs=1024 seek=8
+    dd if=${UBOOT_PATH}/u-boot-sunxi-with-spl.bin conv=notrunc,sync of=/dev/${DISK_MD} bs=1024 seek=8
     dd if=${UBOOT_PATH}/u-boot.img conv=notrunc,sync of=/dev/${DISK_MD} \
 	bs=1024 seek=40
     disk_partition_mbr

--- a/board/BananaPi/setup.sh
+++ b/board/BananaPi/setup.sh
@@ -9,7 +9,7 @@ UBOOT_PATH="/usr/local/share/u-boot/${SUNXI_UBOOT}"
 
 allwinner_partition_image ( ) {
     echo "Installing U-Boot files"
-    dd if=${UBOOT_PATH}/sunxi-spl.bin of=/dev/${DISK_MD} bs=1024 seek=8
+    dd if=${UBOOT_PATH}/u-boot-sunxi-with-spl.bin conv=notrunc,sync of=/dev/${DISK_MD} bs=1024 seek=8
     dd if=${UBOOT_PATH}/u-boot.img conv=notrunc,sync of=/dev/${DISK_MD} \
 	bs=1024 seek=40
     disk_partition_mbr

--- a/board/Cubieboard2/setup.sh
+++ b/board/Cubieboard2/setup.sh
@@ -9,7 +9,7 @@ UBOOT_PATH="/usr/local/share/u-boot/${SUNXI_UBOOT}"
 
 allwinner_partition_image ( ) {
     echo "Installing U-Boot files"
-    dd if=${UBOOT_PATH}/sunxi-spl.bin of=/dev/${DISK_MD} bs=1024 seek=8
+    dd if=${UBOOT_PATH}/u-boot-sunxi-with-spl.bin conv=notrunc,sync of=/dev/${DISK_MD} bs=1024 seek=8
     dd if=${UBOOT_PATH}/u-boot.img conv=notrunc,sync of=/dev/${DISK_MD} \
 	bs=1024 seek=40
     disk_partition_mbr

--- a/board/OrangePi-Plus2E/setup.sh
+++ b/board/OrangePi-Plus2E/setup.sh
@@ -9,7 +9,7 @@ UBOOT_PATH="/usr/local/share/u-boot/${SUNXI_UBOOT}"
 
 allwinner_partition_image ( ) {
     echo "Installing U-Boot files"
-    dd if=${UBOOT_PATH}/sunxi-spl.bin of=/dev/${DISK_MD} bs=1024 seek=8
+    dd if=${UBOOT_PATH}/u-boot-sunxi-with-spl.bin conv=notrunc,sync of=/dev/${DISK_MD} bs=1024 seek=8
     dd if=${UBOOT_PATH}/u-boot.img conv=notrunc,sync of=/dev/${DISK_MD} \
 	bs=1024 seek=40
     disk_partition_mbr


### PR DESCRIPTION
As the result of [r431327](https://svnweb.freebsd.org/ports?view=revision&revision=431327) in ports.
Also use conv=notrunc,sync when writing, as mentioned in https://github.com/freebsd/crochet/issues/191#issuecomment-313300456.

Fixes #190 
Fixes #191