### PR TITLE
[Issue-207] By default add the name of the board to the image's name

### DIFF
--- a/config.sh.sample
+++ b/config.sh.sample
@@ -209,7 +209,7 @@
 # FreeBSD-${TARGET_ARCH}-${FREEBSD_MAJOR_VERSION}-${KERNCONF}.img
 #IMG=${WORKDIR}/FreeBSD-${KERNCONF}.img
 #IMGDIR=${WORKDIR}
-#IMGNAME='FreeBSD-${TARGET_ARCH}-${FREEBSD_MAJOR_VERSION}-${KERNCONF}'
+#IMGNAME='FreeBSD-${TARGET_ARCH}-${FREEBSD_MAJOR_VERSION}-${KERNCONF}-${BOARDNAME}.img'
 
 # Unset this to suppress installworld.  This is
 # useful when experimenting with boot and kernel

--- a/lib/board.sh
+++ b/lib/board.sh
@@ -26,10 +26,14 @@ FREEBSD_INSTALL_WORLD=y
 # List of all board dirs.
 BOARDDIRS=""
 
+# the board's name, later to be used in IMGNAMe
+BOARDNAME=""
+
 # $1: name of board directory
 #
 board_setup ( ) {
     BOARDDIR=${TOPDIR}/board/$1
+    BOARDNAME=$1
     if [ ! -e ${BOARDDIR}/setup.sh ]; then
         echo "Can't setup board $1."
         echo "No setup.sh in ${BOARDDIR}."
@@ -54,9 +58,9 @@ board_generate_image_name ( ) {
     fi
     if [ -z "${IMG}" ]; then
         if [ -z "${SOURCE_VERSION}" ]; then
-           IMG=${_IMGDIR}/FreeBSD-${TARGET_ARCH}-${FREEBSD_MAJOR_VERSION}-${KERNCONF}.img
+           IMG=${_IMGDIR}/FreeBSD-${TARGET_ARCH}-${FREEBSD_MAJOR_VERSION}-${KERNCONF}-${BOARDNAME}.img
 	else
-           IMG=${_IMGDIR}/FreeBSD-${TARGET_ARCH}-${FREEBSD_VERSION}-${KERNCONF}-${SOURCE_VERSION}.img
+           IMG=${_IMGDIR}/FreeBSD-${TARGET_ARCH}-${FREEBSD_VERSION}-${KERNCONF}-${SOURCE_VERSION}-${BOARDNAME}.img
 	fi
     fi
     echo "Image name is:"


### PR DESCRIPTION
The board_setup function now saves the board's name to BOARDNAME, and
board_generate_image_name will later use it to add it to the image's name.

For https://github.com/freebsd/crochet/issues/207
