### PR TITLE
Support for Raspberry Pi Compute Module 3 Lite

### DIFF
--- a/board/RaspberryPiCM3L/README
+++ b/board/RaspberryPiCM3L/README
@@ -1,0 +1,29 @@
+Raspberry Pi 3 is supported as of Oct 2016.
+
+============================================================
+
+What is a Raspberry Pi 3?
+--------------------
+
+The Raspberry Pi 3 is a quad-core 64-bit ARM single board computer.
+Details can be found at:
+
+   https://www.raspberrypi.org/products/raspberry-pi-3-model-b/
+
+You boot it from a MicroSDHC card with the system image.
+
+Once you have the Raspberry Pi 3 working, you can expand it by
+connecting it to Ethernet, adding USB peripherals (such as external
+disk drives) or attaching new hardware to the connectors on the board.
+
+============================================================
+
+How to boot the Raspberry Pi 3
+--------------------------------
+
+1. Connect the board to a HDMI display, network, and USB keyboard.
+   Network alone will work if you wish to boot headless.
+
+2. Insert a microSD card with this generated image.
+
+3. Power on the board by connecting it to a 5v power supply

--- a/board/RaspberryPiCM3L/README
+++ b/board/RaspberryPiCM3L/README
@@ -2,27 +2,31 @@ Raspberry Pi 3 is supported as of Oct 2016.
 
 ============================================================
 
-What is a Raspberry Pi 3?
+What is a Raspberry Pi Compute Module 3 Lite?
 --------------------
 
-The Raspberry Pi 3 is a quad-core 64-bit ARM single board computer.
-Details can be found at:
+The Raspberry Pi Compute Module 3 Lite is a Raspberry Pi in 3 in a DDR2 SODIMM
+form factor. The 'Lite' version DOES NOT have embedded flash memory, and must
+be booted from an MicroSDHC card.
 
-   https://www.raspberrypi.org/products/raspberry-pi-3-model-b/
+	https://www.raspberrypi.org/products/compute-module-3-lite/
 
-You boot it from a MicroSDHC card with the system image.
+To work with the Compute Module you need a carrier board such as the 'Compute 
+Module IO Board' (CMIO):
 
-Once you have the Raspberry Pi 3 working, you can expand it by
-connecting it to Ethernet, adding USB peripherals (such as external
-disk drives) or attaching new hardware to the connectors on the board.
+	https://www.raspberrypi.org/products/compute-module-io-board-v3/
+	
+Compute Module Data sheet:
+
+	https://www.raspberrypi.org/documentation/hardware/computemodule/cm-designguide.md
 
 ============================================================
 
-How to boot the Raspberry Pi 3
+How to boot the Raspberry Pi Compute Module 3 Lite
 --------------------------------
 
-1. Connect the board to a HDMI display, network, and USB keyboard.
-   Network alone will work if you wish to boot headless.
+1. Insert the Compute Module into an appropriate carrier board, and attach
+   peripherals.
 
 2. Insert a microSD card with this generated image.
 

--- a/board/RaspberryPiCM3L/overlay/boot/loader.conf
+++ b/board/RaspberryPiCM3L/overlay/boot/loader.conf
@@ -1,0 +1,1 @@
+geom_label_load="YES"		# File system labels (see glabel(8))

--- a/board/RaspberryPiCM3L/overlay/boot/loader.rc
+++ b/board/RaspberryPiCM3L/overlay/boot/loader.rc
@@ -1,0 +1,15 @@
+\ Load Forth utility functions
+include /boot/loader.4th
+
+\ Read and processes loader.conf variables
+start
+
+\ Tests for password -- executes autoboot first if a password was defined
+check-password
+
+\ Uncomment to enable boot menu
+\ include /boot/beastie.4th
+\ beastie-start
+
+\ Unless set otherwise, autoboot is automatic at this point
+

--- a/board/RaspberryPiCM3L/overlay/etc/fstab
+++ b/board/RaspberryPiCM3L/overlay/etc/fstab
@@ -1,0 +1,5 @@
+/dev/mmcsd0s1	/boot/efi	msdosfs rw,noatime	0 0
+/dev/mmcsd0s2a	/		ufs rw,noatime		1 1
+md		/tmp		mfs rw,noatime,-s50m	0 0
+md		/var/log	mfs rw,noatime,-s15m	0 0
+md		/var/tmp	mfs rw,noatime,-s12m	0 0

--- a/board/RaspberryPiCM3L/overlay/etc/rc.conf
+++ b/board/RaspberryPiCM3L/overlay/etc/rc.conf
@@ -1,0 +1,17 @@
+hostname="rpi3"
+ifconfig_ue0="DHCP"
+sshd_enable="YES"
+
+powerd_enable="YES"
+
+# Nice if you have a network, else annoying.
+#ntpd_enable="YES"
+ntpd_sync_on_start="YES"
+
+# Uncomment to disable common services (more memory)
+#cron_enable="NO"
+#syslogd_enable="NO"
+sendmail_enable="NONE"
+sendmail_submit_enable="NO"
+sendmail_outbound_enable="NO"
+sendmail_msp_queue_enable="NO"

--- a/board/RaspberryPiCM3L/setup.sh
+++ b/board/RaspberryPiCM3L/setup.sh
@@ -1,0 +1,92 @@
+KERNCONF=GENERIC
+RPI3_UBOOT_PORT="u-boot-rpi3"
+RPI3_UBOOT_BIN="u-boot.bin"
+RPI3_UBOOT_PATH="/usr/local/share/u-boot/${RPI3_UBOOT_PORT}"
+IMAGE_SIZE=$((2000 * 1000 * 1000))
+TARGET_ARCH=aarch64
+TARGET=aarch64
+DTB_REPO="https://github.com/raspberrypi/firmware/blob/master/boot/"
+RPICM3_FIRMWARE_PORT="rpi-firmware"
+RPICM3_FIRMWARE_PATH="/usr/local/share/${RPICM3_FIRMWARE_PORT}"
+
+# Not used - just in case someone wants to use a manual ubldr.  Obtained
+# from 'printenv' in boot0: kernel_addr_r=0x42000000
+#UBLDR_LOADADDR=0x42000000
+
+rpi3_check_uboot ( ) {
+    uboot_port_test ${RPI3_UBOOT_PORT} ${RPI3_UBOOT_BIN}
+}
+strategy_add $PHASE_CHECK rpi3_check_uboot
+
+rpi_cm3_check_firmware ( ) {
+    if [ ! -d ${RPICM3_FIRMWARE_PATH} ]; then
+        echo "please install sysutils/${RPICM3_FIRMWARE_PORT} and re-run this script."
+	echo "You can do this with:"
+	echo "$ sudo pkg install sysutils/${RPICM3_FIRMWARE_PORT}"
+	echo "or by building the port:"
+	echo " $ cd /usr/ports/sysutils/${RPICM3_FIRMWARE_PORT}"
+	echo " $ make install"
+	exit 1
+    fi
+    echo "Found rpi-firmware port in:"
+    echo "    ${RPICM3_FIRMWARE_PORT}"
+}
+strategy_add $PHASE_CHECK rpi_cm3_check_firmware
+
+#
+# RPi3 uses EFI, so the first partition will be a FAT partition.
+#
+rpi3_partition_image ( ) {
+    disk_partition_mbr
+    # Use FAT16.  The minimum space requirement for FAT32 is too big for this.
+    disk_fat_create 50m 16
+    disk_ufs_create
+}
+strategy_add $PHASE_PARTITION_LWW rpi3_partition_image
+
+raspberry_pi_populate_boot_partition ( ) {
+    echo bootaa64 > startup.nsh
+    mkdir -p EFI/BOOT
+
+    cp ${RPICM3_FIRMWARE_PATH}/LICENCE.broadcom .
+    cp ${UBOOT_PATH}/README .
+    cp ${RPICM3_FIRMWARE_PATH}/bootcode.bin .
+    cp ${RPICM3_FIRMWARE_PATH}/fixup.dat .
+    cp ${RPICM3_FIRMWARE_PATH}/fixup_cd.dat .
+    cp ${RPICM3_FIRMWARE_PATH}/fixup_x.dat .
+    cp ${RPICM3_FIRMWARE_PATH}/start.elf .
+    cp ${RPICM3_FIRMWARE_PATH}/start_cd.elf .
+    cp ${RPICM3_FIRMWARE_PATH}/start_x.elf .
+    cp ${UBOOT_PATH}/u-boot.bin .
+    cp ${UBOOT_PATH}/armstub8.bin .
+
+    # Populate config.txt
+    echo "arm_control=0x200" > config.txt
+    echo "dtparam=audio=on,i2c_arm=on,spi=on" >> config.txt
+    echo "dtoverlay=mmc" >> config.txt
+    echo "dtoverlay=pi3-disable-bt" >> config.txt
+    echo "device_tree_address=0x4000" >> config.txt
+    echo "kernel=u-boot.bin" >> config.txt
+
+    # Fetch the dtb
+    dtb="bcm2710-rpi-cm3.dtb"
+    fetch -o ${dtb} "${DTB_REPO}/${dtb}?raw=true"
+
+    # Fetch all the overlays we need
+    mkdir overlays
+    overlays="mmc.dtbo pi3-disable-bt.dtbo"
+    for i in ${overlays}; do
+        fetch -o overlays/${i} "${DTB_REPO}/overlays/${i}?raw=true"
+    done
+
+}
+strategy_add $PHASE_BOOT_INSTALL raspberry_pi_populate_boot_partition
+
+# Build & install loader.efi.
+strategy_add $PHASE_BUILD_OTHER freebsd_loader_efi_build
+strategy_add $PHASE_BOOT_INSTALL freebsd_loader_efi_copy EFI/BOOT/bootaa64.efi
+
+# RPi3 puts the kernel on the FreeBSD UFS partition.
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL board_default_installkernel .
+# overlay/etc/fstab mounts the FAT partition at /boot/efi
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL mkdir -p boot/efi

--- a/config.sh.sample
+++ b/config.sh.sample
@@ -36,6 +36,7 @@
 #board_setup RaspberryPi
 #board_setup RaspberryPi2
 #board_setup RaspberryPi3
+#board_setup RaspberryPiCM3L
 #board_setup VersatilePB
 #board_setup Wandboard
 #board_setup ZedBoard


### PR DESCRIPTION
These commits add a directory for the Raspberry Pi Compute Module 3 Lite and create README and setup.sh files for the CM3. The setup script is mostly identical to the RPi3 setup script except that a different device tree is fetched and the `sysutils/rpi-firmware` port is used for firmware instead of `sysutils/u-boot-rpi3`. The `u-boot-rpi3` firmware does not seem to select the correct device tree during boot whereas `rpi-firmware` does. 

EDIT: The image that this generates also works on the Raspberry Pi Compute Module 3 (with eMMC), with two caveats: 

1. Size: the image size must be kept <4GB since the Compute Module 3 only has 4GB of embedded flash.

2. Difficult to flash eMMC: [The official method for flashing the CM3](https://www.raspberrypi.org/documentation/hardware/computemodule/cm-emmc-flashing.md) only officially works on Debian-based distros (or Cygwin). This means that the CM3 can be reliably flashed from an RPi running Raspbian. However `rpiboot` is not reliable on FreeBSD. I've gotten it to work on *one* FreeBSD computer, but not others for unclear reasons. Presumably due to differing versions of `libusb`...

With the above in mind `board/RaspberryPiCM3` could be added as a link to `board/RaspberryPiCM3L`