### PR TITLE
RPi - update UBOOT_BIN file name

### DIFF
--- a/board/RaspberryPi/setup.sh
+++ b/board/RaspberryPi/setup.sh
@@ -1,6 +1,6 @@
 KERNCONF=RPI-B
 RPI_UBOOT_PORT="u-boot-rpi"
-RPI_UBOOT_BIN="u-boot.img"
+RPI_UBOOT_BIN="u-boot.bin"
 RPI_FIRMWARE_SRC=/usr/local/share/u-boot/${RPI_UBOOT_PORT}
 RPI_GPU_MEM=32
 IMAGE_SIZE=$((1000 * 1000 * 1000)) # 1 GB default


### PR DESCRIPTION
Since [u-boot 2017.09](https://svnweb.freebsd.org/ports/head/sysutils/u-boot-master/Makefile?view=markup&pathrev=454262#l65) the BIN file is named `u-boot.bin`.
Currently it will fail, asking to install `u-boot-rpi`, albeit it's already installed.