### PR TITLE
increase IMAGE_SIZE for RaspberryPi2 to 3GB

### DIFF
--- a/board/RaspberryPi2/setup.sh
+++ b/board/RaspberryPi2/setup.sh
@@ -2,7 +2,7 @@ KERNCONF=GENERIC
 UBLDR_LOADADDR=0x2000000
 RPI_UBOOT="u-boot-rpi2"
 RPI_UBOOT_BIN="u-boot.bin"
-IMAGE_SIZE=$((1000 * 1000 * 1000)) # 1 GB default
+IMAGE_SIZE=$((3 * 1000 * 1000 * 1000)) # 1 GB too small - go with 3 GB default
 TARGET_ARCH=armv6
 
 UBOOT_PATH="/usr/local/share/u-boot/${RPI_UBOOT}"


### PR DESCRIPTION
Its hard to find a micro SD or flash smaller than 4GB.  The RPi3 image
no longer fits in 2GB so 3GB seem like a reasonable choice.