### PR TITLE
checkout for board directory for Orange Pi One

### DIFF
--- a/board/OrangePi-One/opione-workaround.dts
+++ b/board/OrangePi-One/opione-workaround.dts
@@ -1,0 +1,6 @@
+#include "sun8i-h3-orangepi-one.dts"
+
+&codec {
+ status = "disabled";
+};
+ 

--- a/board/OrangePi-One/overlay/etc/fstab
+++ b/board/OrangePi-One/overlay/etc/fstab
@@ -1,0 +1,6 @@
+/dev/mmcsd0s1	/boot/msdos	msdosfs rw,noatime	0 0
+/dev/mmcsd0s2a	/		ufs rw,noatime		1 1
+md		/tmp		mfs rw,noatime,-s30m	0 0
+md		/var/log	mfs rw,noatime,-s15m	0 0
+md		/var/tmp	mfs rw,noatime,-s12m	0 0
+

--- a/board/OrangePi-One/overlay/etc/rc.conf
+++ b/board/OrangePi-One/overlay/etc/rc.conf
@@ -1,0 +1,15 @@
+hostname="orangepi-one"
+ifconfig_awg0="DHCP"
+sshd_enable="YES"
+
+# Nice if you have a network, else annoying.
+#ntpd_enable="YES"
+ntpd_sync_on_start="YES"
+
+# Uncomment to disable common services (more memory)
+#cron_enable="NO"
+#syslogd_enable="NO"
+
+sendmail_submit_enable="NO"
+sendmail_outbound_enable="NO"
+sendmail_msp_queue_enable="NO"

--- a/board/OrangePi-One/setup.sh
+++ b/board/OrangePi-One/setup.sh
@@ -1,0 +1,122 @@
+KERNCONF=GENERIC
+UBLDR_LOADADDR=0x42000000
+SUNXI_UBOOT="u-boot-orangepi-one"
+SUNXI_UBOOT_BIN="u-boot.img"
+# image size fits a 2+ GB root image in first UFS partition
+IMAGE_SIZE=$((3 * 1000 * 1000 * 1000))
+TARGET_ARCH=armv6
+
+FREEBSD_SRC=/usr/src
+# BOARD_BOOT_MOUNTPOINT
+# BOARD_FREEBSD_MOUNTPOINT
+# BOARD_CURRENT_MOUNTPOINT
+
+UBOOT_PATH="/usr/local/share/u-boot/${SUNXI_UBOOT}"
+
+allwinner_partition_image ( ) {
+    echo "Installing U-Boot files"
+    dd if=${UBOOT_PATH}/u-boot-sunxi-with-spl.bin conv=notrunc,sync \
+       of=/dev/${DISK_MD} bs=1024 seek=8
+    dd if=${UBOOT_PATH}/u-boot.img conv=notrunc,sync \
+       of=/dev/${DISK_MD} bs=1024 seek=40
+    disk_partition_mbr
+    disk_fat_create 32m 16 1m
+    # note: /usr/{local,ports} elsewhere - 2.5g for base
+    disk_ufs_create `expr 5 \* 512`m
+    # rest of disk - either use growfs on prior or add partitions if needed
+    #disk_ufs_create ...
+}
+strategy_add $PHASE_PARTITION_LWW allwinner_partition_image
+
+allwinner_check_uboot ( ) {
+    uboot_port_test ${SUNXI_UBOOT} ${SUNXI_UBOOT_BIN}
+}
+strategy_add $PHASE_CHECK allwinner_check_uboot
+
+strategy_add $PHASE_BUILD_OTHER freebsd_ubldr_build \
+	     UBLDR_LOADADDR=${UBLDR_LOADADDR}
+strategy_add $PHASE_BOOT_INSTALL freebsd_ubldr_copy_ubldr .
+
+#  use either as-is or workaround dts file
+opi_use_dts="as-is"
+if [ x"$opi_use_dts" = xworkaround ] ; then
+    opi_dts_file_base=opione-workaround
+    opi_dts_dir=${BOARDDIR}
+else
+    opi_dts_file_base=sun8i-h3-orangepi-one
+    opi_dts_dir=/usr/src/sys/gnu/dts/arm
+fi
+#  use base and dir to get full dts path
+opi_dts_full_path=${opi_dts_dir}/${opi_dts_file_base}.dts
+
+make_workaround_fdt ( ) {
+    mkdir -p ${WORKDIR}/opione
+    # note: the echo expands the directory variables
+    cmd=`echo MACHINE=arm /usr/src/sys/tools/fdt/make_dtb.sh \
+    	      ${FREEBSD_SRC}/sys ${opi_dts_full_path} \
+	      ${WORKDIR}/opione`
+    echo === Running: $cmd ===
+    sh -c "$cmd"
+    if [ $? != 0 ] ; then
+	echo make_workaround_fdt: command failed
+	echo "  " $cmd
+	exit 1
+    fi
+}
+
+copy_workaround_fdt ( ) {
+    destdir=$1
+    if [ x = "x$destdir" ] ; then
+	echo make_workaround_fdt: needs a destination directory argument
+	exit 1
+    else
+	if [ "x$destdir" = xboot ] ; then
+	    destdir=${BOARD_BOOT_MOUNTPOINT}  # not set at define time
+	elif [ "x$destdir" = xbsd ] ; then
+	    destdir=${BOARD_FREEBSD_MOUNTPOINT}/boot/dtb
+	fi
+	if [ ! -d $destdir ] ; then
+	    echo make_workaround_fdt: $destdir is not a directory
+	    exit 1
+	fi
+    fi
+    echo === Copy dtb file to ${destdir}/sun8i-h3-orangepi-one.dtb ===
+    cp ${WORKDIR}/opione/${opi_dts_file_base}.dtb \
+       ${destdir}/sun8i-h3-orangepi-one.dtb
+}
+
+#strategy_add $PHASE_BOOT_INSTALL freebsd_install_fdt \
+#	     ../gnu/dts/arm/sun8i-h3-orangepi-one.dts \
+#	     ${BOARD_BOOT_MOUNTPOINT}/sun8i-h3-orangepi-one.dtb
+#strategy_add $PHASE_FREEBSD_BOARD_INSTALL freebsd_install_fdt \
+#	     ../gnu/dts/arm/sun8i-h3-orangepi-one.dts \
+#	     ${BOARD_FREEBSD_MOUNTPOINT}/boot/dtb/orangepi-one.dtb
+
+#  compiles dts twice but no big deal
+strategy_add $PHASE_BOOT_INSTALL make_workaround_fdt
+strategy_add $PHASE_BOOT_INSTALL copy_workaround_fdt boot
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL copy_workaround_fdt bsd
+
+make_boot_install_boot_scr_file ( ) {
+    echo "echo \"Loading U-boot loader: ubldr.bin\"" \
+	 > ${BOARD_BOOT_MOUNTPOINT}/boot.cmd
+#  not sure if we need to pre-load the dtb file
+#    echo "" \
+#	 >> ${BOARD_BOOT_MOUNTPOINT}/boot.cmd
+    echo "load \${devtype} \${devnum}:${distro_bootpart}"\
+	 "${UBLDR_LOADADDR}" ubldr.bin \
+	 >> ${BOARD_BOOT_MOUNTPOINT}/boot.cmd
+    echo "go ${UBLDR_LOADADDR}" \
+	 >> ${BOARD_BOOT_MOUNTPOINT}/boot.cmd
+    mkimage -A arm -T script -C none -n "Boot Commands" \
+	    -d ${BOARD_BOOT_MOUNTPOINT}/boot.cmd \
+	    ${BOARD_BOOT_MOUNTPOINT}/boot.scr
+}
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL make_boot_install_boot_scr_file
+
+# BeagleBone puts the kernel on the FreeBSD UFS partition.
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL board_default_installkernel .
+# overlay/etc/fstab mounts the FAT partition at /boot/msdos
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL mkdir -p boot/msdos
+# ubldr help and config files go on the UFS partition (after boot dir exists)
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL freebsd_ubldr_copy boot


### PR DESCRIPTION
This board directory has been in use for about two weeks.  A number of
ports built on an Orange Pi PC Plus have been tested on this platform
and work.  Both use the armv7 architecture but TARGET_ARCH is set to
armv6 so there may be room for improvement.