### PR TITLE
Orange Pi PC Plus and One from TARGET_ARCH=armv6 to armv7

### DIFF
--- a/board/OrangePi-One/setup.sh
+++ b/board/OrangePi-One/setup.sh
@@ -4,7 +4,7 @@ SUNXI_UBOOT="u-boot-orangepi-one"
 SUNXI_UBOOT_BIN="u-boot.img"
 # image size fits a 2+ GB root image in first UFS partition
 IMAGE_SIZE=$((3 * 1000 * 1000 * 1000))
-TARGET_ARCH=armv6
+TARGET_ARCH=armv7
 
 FREEBSD_SRC=/usr/src
 # BOARD_BOOT_MOUNTPOINT

--- a/board/OrangePi-PC-Plus/setup.sh
+++ b/board/OrangePi-PC-Plus/setup.sh
@@ -4,7 +4,7 @@ SUNXI_UBOOT="u-boot-orangepi-pc-plus"
 SUNXI_UBOOT_BIN="u-boot.img"
 # image size fits a 2+ GB root image in first UFS partition
 IMAGE_SIZE=$((3 * 1000 * 1000 * 1000))
-TARGET_ARCH=armv6
+TARGET_ARCH=armv7
 
 FREEBSD_SRC=/usr/src
 # BOARD_BOOT_MOUNTPOINT


### PR DESCRIPTION
…armv7

The image file built and ran as armv6 but the processor is armv7.  The
Orange Pi Plus2E, Orange Pi PC Plus, and Orange Pi One are all based
on the AllWinner H3 which is a cortex-7a arm.  This change was tested
on Orange Pi PC Plus and Orange Pi One.  The board setup for Orange Pi
Plus2E was not changed since I don't have a board to test against.