### PR TITLE
Add a README file to the OrangePi-PC-Plus directory

### DIFF
--- a/board/OrangePi-PC-Plus/README
+++ b/board/OrangePi-PC-Plus/README
@@ -1,0 +1,48 @@
+Orange Pi PC Plus
+
+The Orange Pi PC and Orange Pi PC Plus are single board computers
+(SBC) based on the Allwinner H3 system on a chip (SoC) with 1 GB DDR3
+RAM.  Both have one 10/100 mbit Ethernet, UART, three USB 2.0 port,
+one USB 2.0 OTG port, and one micro SD card slot.  The Orange Pi PC
+Plus also has 8GB EMMC flash on chip and WiFi with antenna.  Both also
+have a CSI camera interface (which I have not tried).  It draws up to
+5V/2A power from a barrel connector.
+
+These boards are very inexpensive (about $20-$30 plus you'll need case
+and power cord or power supply).  See orangepi.org for details.
+
+Video over the HDMI does not work due to lack of completed support for
+the ARM Mali-400 GPU in FreeBSD.
+
+To build you need FreeBSD source (preferably in /usr/src) and you need
+to build the port sysutils/u-boot-orangepi-pc-plus.  Use the patch file
+in https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=227506 until this
+port becomes available (patch from /usr/ports).
+
+It is handy to have a USB serial adaptor for degugging since HDMI
+doesn't work.
+
+============================================================
+
+Build instructions:
+
+  Get latest source (if you don't already have it).
+
+    ( cd /usr && svn co https://svn.freebsd.org/base/head )
+    ( cd /usr && svn co https://svn.freebsd.org/ports/head )
+
+  Build u-boot port.
+
+    ( cd /usr/ports/sysutils/u-boot-orangepi-pc-plus && make install )
+
+  Build crochet image.
+
+    sh crochet.sh -v -b OrangePi-PC-Plus
+
+  Follow directions to use dd to copy an image to micro SD.
+
+============================================================
+
+Unfortunately, when testing this I was using an Orange Pi PC (not
+Plus) so this does work for the PC but may or may not work with the PC
+Plus.  Will fix that when I get a PC Plus (fairly soon).


### PR DESCRIPTION
The README does give a status which is essentially untested since I
accidentally tested with an OrangePi-PC card and don't have an
OrangePi-PC-Plus handy (yet).  When I get one I'll update the status
and make any changes as needed.