### PR TITLE
Initial commit of OrangePi-PC board directory

### DIFF
--- a/board/OrangePi-PC/README
+++ b/board/OrangePi-PC/README
@@ -1,0 +1,40 @@
+Orange Pi PC
+
+The Orange Pi PC and Orange Pi PC Plus are single board computers
+(SBC) based on the Allwinner H3 system on a chip (SoC) with 1 GB DDR3
+RAM.  Both have one 10/100 mbit Ethernet, UART, three USB 2.0 port,
+one USB 2.0 OTG port, and one micro SD card slot.  The Orange Pi PC
+Plus also has 8GB EMMC flash on chip and WiFi with antenna.  Both also
+have a CSI camera interface (which I have not tried).  It draws up to
+5V/2A power from a barrel connector.
+
+These boards are very inexpensive (about $20-$30 plus you'll need case
+and power cord or power supply).  See orangepi.org for details.
+
+Video over the HDMI does not work due to lack of completed support for
+the ARM Mali-400 GPU in FreeBSD.
+
+To build you need FreeBSD source (preferably in /usr/src) and you need
+to build the port sysutils/u-boot-orangepi-pc.
+
+It is handy to have a USB serial adaptor for degugging since HDMI
+doesn't work.
+
+============================================================
+
+Build instructions:
+
+  Get latest source (if you don't already have it).
+
+    ( cd /usr && svn co https://svn.freebsd.org/base/head )
+    ( cd /usr && svn co https://svn.freebsd.org/ports/head )
+
+  Build u-boot port.
+
+    ( cd /usr/ports/sysutils/u-boot-orangepi-pc && make install )
+
+  Build crochet image.
+
+    sh crochet.sh -v -b OrangePi-PC
+
+  Follow directions to use dd to copy an image to micro SD.

--- a/board/OrangePi-PC/opipc-workaround.dts
+++ b/board/OrangePi-PC/opipc-workaround.dts
@@ -1,0 +1,6 @@
+#include "sun8i-h3-orangepi-pc.dts"
+
+&codec {
+ status = "disabled";
+};
+ 

--- a/board/OrangePi-PC/overlay/etc/fstab
+++ b/board/OrangePi-PC/overlay/etc/fstab
@@ -1,0 +1,6 @@
+/dev/mmcsd0s1	/boot/msdos	msdosfs rw,noatime	0 0
+/dev/mmcsd0s2a	/		ufs rw,noatime		1 1
+md		/tmp		mfs rw,noatime,-s30m	0 0
+md		/var/log	mfs rw,noatime,-s15m	0 0
+md		/var/tmp	mfs rw,noatime,-s12m	0 0
+

--- a/board/OrangePi-PC/overlay/etc/rc.conf
+++ b/board/OrangePi-PC/overlay/etc/rc.conf
@@ -1,0 +1,15 @@
+hostname="orangepi-pc"
+ifconfig_awg0="DHCP"
+sshd_enable="YES"
+
+# Nice if you have a network, else annoying.
+#ntpd_enable="YES"
+ntpd_sync_on_start="YES"
+
+# Uncomment to disable common services (more memory)
+#cron_enable="NO"
+#syslogd_enable="NO"
+
+sendmail_submit_enable="NO"
+sendmail_outbound_enable="NO"
+sendmail_msp_queue_enable="NO"

--- a/board/OrangePi-PC/setup.sh
+++ b/board/OrangePi-PC/setup.sh
@@ -1,0 +1,122 @@
+KERNCONF=GENERIC
+UBLDR_LOADADDR=0x42000000
+SUNXI_UBOOT="u-boot-orangepi-pc"
+SUNXI_UBOOT_BIN="u-boot.img"
+# image size fits a 2+ GB root image in first UFS partition
+IMAGE_SIZE=$((3 * 1000 * 1000 * 1000))
+TARGET_ARCH=armv7
+
+FREEBSD_SRC=/usr/src
+# BOARD_BOOT_MOUNTPOINT
+# BOARD_FREEBSD_MOUNTPOINT
+# BOARD_CURRENT_MOUNTPOINT
+
+UBOOT_PATH="/usr/local/share/u-boot/${SUNXI_UBOOT}"
+
+allwinner_partition_image ( ) {
+    echo "Installing U-Boot files"
+    dd if=${UBOOT_PATH}/u-boot-sunxi-with-spl.bin conv=notrunc,sync \
+       of=/dev/${DISK_MD} bs=1024 seek=8
+    dd if=${UBOOT_PATH}/u-boot.img conv=notrunc,sync \
+       of=/dev/${DISK_MD} bs=1024 seek=40
+    disk_partition_mbr
+    disk_fat_create 32m 16 1m
+    # note: /usr/{local,ports} elsewhere - 2.5g for base
+    disk_ufs_create `expr 5 \* 512`m
+    # rest of disk - either use growfs on prior or add partitions if needed
+    #disk_ufs_create ...
+}
+strategy_add $PHASE_PARTITION_LWW allwinner_partition_image
+
+allwinner_check_uboot ( ) {
+    uboot_port_test ${SUNXI_UBOOT} ${SUNXI_UBOOT_BIN}
+}
+strategy_add $PHASE_CHECK allwinner_check_uboot
+
+strategy_add $PHASE_BUILD_OTHER freebsd_ubldr_build \
+	     UBLDR_LOADADDR=${UBLDR_LOADADDR}
+strategy_add $PHASE_BOOT_INSTALL freebsd_ubldr_copy_ubldr .
+
+#  use either as-is or workaround dts file
+opi_use_dts="workaround"
+if [ x"$opi_use_dts" = xworkaround ] ; then
+    opi_dts_file_base=opipc-workaround
+    opi_dts_dir=${BOARDDIR}
+else
+    opi_dts_file_base=sun8i-h3-orangepi-pc
+    opi_dts_dir=/usr/src/sys/gnu/dts/arm
+fi
+#  use base and dir to get full dts path
+opi_dts_full_path=${opi_dts_dir}/${opi_dts_file_base}.dts
+
+make_workaround_fdt ( ) {
+    mkdir -p ${WORKDIR}/opipc
+    # note: the echo expands the directory variables
+    cmd=`echo MACHINE=arm /usr/src/sys/tools/fdt/make_dtb.sh \
+    	      ${FREEBSD_SRC}/sys ${opi_dts_full_path} \
+	      ${WORKDIR}/opipc`
+    echo === Running: $cmd ===
+    sh -c "$cmd"
+    if [ $? != 0 ] ; then
+	echo make_workaround_fdt: command failed
+	echo "  " $cmd
+	exit 1
+    fi
+}
+
+copy_workaround_fdt ( ) {
+    destdir=$1
+    if [ x = "x$destdir" ] ; then
+	echo make_workaround_fdt: needs a destination directory argument
+	exit 1
+    else
+	if [ "x$destdir" = xboot ] ; then
+	    destdir=${BOARD_BOOT_MOUNTPOINT}  # not set at define time
+	elif [ "x$destdir" = xbsd ] ; then
+	    destdir=${BOARD_FREEBSD_MOUNTPOINT}/boot/dtb
+	fi
+	if [ ! -d $destdir ] ; then
+	    echo make_workaround_fdt: $destdir is not a directory
+	    exit 1
+	fi
+    fi
+    echo === Copy dtb file to ${destdir}/sun8i-h3-orangepi-pc.dtb ===
+    cp ${WORKDIR}/opipc/${opi_dts_file_base}.dtb \
+       ${destdir}/sun8i-h3-orangepi-pc.dtb
+}
+
+#strategy_add $PHASE_BOOT_INSTALL freebsd_install_fdt \
+#	     ../gnu/dts/arm/sun8i-h3-orangepi-pc.dts \
+#	     ${BOARD_BOOT_MOUNTPOINT}/sun8i-h3-orangepi-pc.dtb
+#strategy_add $PHASE_FREEBSD_BOARD_INSTALL freebsd_install_fdt \
+#	     ../gnu/dts/arm/sun8i-h3-orangepi-pc.dts \
+#	     ${BOARD_FREEBSD_MOUNTPOINT}/boot/dtb/orangepi-pc.dtb
+
+#  compiles dts twice but no big deal
+strategy_add $PHASE_BOOT_INSTALL make_workaround_fdt
+strategy_add $PHASE_BOOT_INSTALL copy_workaround_fdt boot
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL copy_workaround_fdt bsd
+
+make_boot_install_boot_scr_file ( ) {
+    echo "echo \"Loading U-boot loader: ubldr.bin\"" \
+	 > ${BOARD_BOOT_MOUNTPOINT}/boot.cmd
+#  not sure if we need to pre-load the dtb file
+#    echo "" \
+#	 >> ${BOARD_BOOT_MOUNTPOINT}/boot.cmd
+    echo "load \${devtype} \${devnum}:${distro_bootpart}"\
+	 "${UBLDR_LOADADDR}" ubldr.bin \
+	 >> ${BOARD_BOOT_MOUNTPOINT}/boot.cmd
+    echo "go ${UBLDR_LOADADDR}" \
+	 >> ${BOARD_BOOT_MOUNTPOINT}/boot.cmd
+    mkimage -A arm -T script -C none -n "Boot Commands" \
+	    -d ${BOARD_BOOT_MOUNTPOINT}/boot.cmd \
+	    ${BOARD_BOOT_MOUNTPOINT}/boot.scr
+}
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL make_boot_install_boot_scr_file
+
+# BeagleBone puts the kernel on the FreeBSD UFS partition.
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL board_default_installkernel .
+# overlay/etc/fstab mounts the FAT partition at /boot/msdos
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL mkdir -p boot/msdos
+# ubldr help and config files go on the UFS partition (after boot dir exists)
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL freebsd_ubldr_copy boot


### PR DESCRIPTION
A workaround is needed in the dts file to avoid the pcm0 device.  The
HDMI doesn't work as with all H3 cards until the ARM Mali-400 GPU is
supported in FreeBSD.