### PR TITLE
Add Pine64-LTS board directory

### DIFF
--- a/board/Pine64-LTS/README
+++ b/board/Pine64-LTS/README
@@ -1,0 +1,31 @@
+Pine64 and Pine64 are no longer made.
+The Pine64-LTS replaces them.
+
+============================================================
+
+What is a Pine64?
+--------------------
+
+The Pine64 is a quad-core 64-bit A53 single board computer.
+Details can be found at:
+
+   http://www.pine64.com/
+
+You boot it from a MicroSDHC card with the system image.
+
+Once you have the Pine64 working, you can expand it by connecting
+it to Ethernet, adding USB peripherals (such as external disk drives
+or wireless network interfaces) or attaching new hardware to the
+connectors on the board.
+
+============================================================
+
+How to boot the Pine64
+--------------------------------
+
+1. Connect the board to a HDMI display, network, and USB keyboard.
+   Network alone will work if you wish to boot headless.
+
+2. Insert a microSD card with this generated image.
+
+3. Power on the board by connecting it to a 5v power supply

--- a/board/Pine64-LTS/overlay/boot/loader.rc
+++ b/board/Pine64-LTS/overlay/boot/loader.rc
@@ -1,0 +1,15 @@
+\ Load Forth utility functions
+include /boot/loader.4th
+
+\ Read and processes loader.conf variables
+start
+
+\ Tests for password -- executes autoboot first if a password was defined
+check-password
+
+\ Uncomment to enable boot menu
+\ include /boot/beastie.4th
+\ beastie-start
+
+\ Unless set otherwise, autoboot is automatic at this point
+

--- a/board/Pine64-LTS/overlay/etc/fstab
+++ b/board/Pine64-LTS/overlay/etc/fstab
@@ -1,0 +1,6 @@
+/dev/mmcsd0s1	/boot/efi	msdosfs rw,noatime	0 0
+/dev/mmcsd0s2a	/		ufs rw,noatime		1 1
+md		/tmp		mfs rw,noatime,-s30m	0 0
+md		/var/log	mfs rw,noatime,-s15m	0 0
+md		/var/tmp	mfs rw,noatime,-s12m	0 0
+

--- a/board/Pine64-LTS/overlay/etc/rc.conf
+++ b/board/Pine64-LTS/overlay/etc/rc.conf
@@ -1,0 +1,15 @@
+hostname="pine64"
+ifconfig_awg0="DHCP"
+sshd_enable="YES"
+
+# Nice if you have a network, else annoying.
+ntpd_enable="YES"
+ntpd_sync_on_start="YES"
+
+# Uncomment to disable common services (more memory)
+#cron_enable="NO"
+#syslogd_enable="NO"
+
+sendmail_submit_enable="NO"
+sendmail_outbound_enable="NO"
+sendmail_msp_queue_enable="NO"

--- a/board/Pine64-LTS/setup.sh
+++ b/board/Pine64-LTS/setup.sh
@@ -1,0 +1,43 @@
+KERNCONF=GENERIC
+PINE64LTS_UBOOT_PORT="u-boot-sopine"
+PINE64LTS_UBOOT_BIN="u-boot-sunxi-with-spl.bin"
+PINE64LTS_UBOOT_PATH="/usr/local/share/u-boot/${PINE64LTS_UBOOT_PORT}"
+IMAGE_SIZE=$((3000 * 1000 * 1000))
+TARGET_ARCH=aarch64
+TARGET=aarch64
+
+# Not used - just in case someone wants to use a manual ubldr.  Obtained
+# from 'printenv' in boot0: kernel_addr_r=0x42000000
+UBLDR_LOADADDR=0x42000000
+
+pine64lts_check_uboot ( ) {
+    uboot_port_test ${PINE64LTS_UBOOT_PORT} ${PINE64LTS_UBOOT_BIN}
+}
+strategy_add $PHASE_CHECK pine64lts_check_uboot
+
+#
+# Pine64-LTS uses EFI, so the first partition will be a FAT partition.
+#
+pine64lts_partition_image ( ) {
+    echo "Installing U-Boot from: ${PINE64LTS_UBOOT_PATH}"
+    dd if=${PINE64LTS_UBOOT_PATH}/${PINE64LTS_UBOOT_BIN} of=/dev/${DISK_MD} conv=notrunc,sync seek=16
+    disk_partition_mbr
+    disk_fat_create 64m 16 16384 -
+    disk_ufs_create
+}
+strategy_add $PHASE_PARTITION_LWW pine64lts_partition_image
+
+pine64lts_uboot_install ( ) {
+    echo bootaa64 > startup.nsh
+    mkdir -p EFI/BOOT
+}
+strategy_add $PHASE_BOOT_INSTALL pine64lts_uboot_install
+
+# Build & install loader.efi.
+strategy_add $PHASE_BUILD_OTHER freebsd_loader_efi_build
+strategy_add $PHASE_BOOT_INSTALL freebsd_loader_efi_copy EFI/BOOT/bootaa64.efi
+
+# Pine64-LTS puts the kernel on the FreeBSD UFS partition.
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL board_default_installkernel .
+# overlay/etc/fstab mounts the FAT partition at /boot/efi
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL mkdir -p boot/efi


### PR DESCRIPTION
based on Pine64 board directory
image size increased to ((3000 * 1000 * 1000))
use u-boot-sopine rather than u-boot-pine64 due to type of DRAM used
using the u-boot-pine64 fails to detect any DRAM in u-boot startup