### PR TITLE
Make bootable on Raspberry Pi 2 with recent rpi-firmware & u-boot-rpi2

### DIFF
--- a/board/RaspberryPi2/setup.sh
+++ b/board/RaspberryPi2/setup.sh
@@ -5,8 +5,9 @@ RPI_UBOOT_BIN="u-boot.bin"
 RPI_FIRMWARE_PORT="rpi-firmware"
 RPI_FIRMWARE_BIN="bootcode.bin"
 RPI_FIRMWARE_PATH="${SHARE_PATH}/${RPI_FIRMWARE_PORT}"
-RPI_FIRMWARE_FILES="bootcode.bin config.txt fixup.dat fixup_cd.dat fixup_db.dat \
-    fixup_x.dat start.elf start_cd.elf start_db.elf start_x.elf"
+RPI_FIRMWARE_FILES="bootcode.bin bcm2709-rpi-2-b.dtb config.txt fixup.dat \
+    fixup_cd.dat fixup_db.dat fixup_x.dat overlays start.elf start_cd.elf \
+    start_db.elf start_x.elf"
 IMAGE_SIZE=$((3 * 1000 * 1000 * 1000)) # 1 GB too small - go with 3 GB default
 TARGET_ARCH=armv6
 


### PR DESCRIPTION
Recently ports sysutils/rpi-firmware and sysutils/u-boot-rpi2 was updated to newer versions. After this updates crochet must install more files on boot partition to make FreeBSD bootable on Raspberry Pi 2 again.
