### PR TITLE
Use better optimization for Raspberry Pi 2

### DIFF
--- a/board/RaspberryPi2/setup.sh
+++ b/board/RaspberryPi2/setup.sh
@@ -9,7 +9,8 @@ RPI_FIRMWARE_FILES="bootcode.bin bcm2709-rpi-2-b.dtb config.txt fixup.dat \
     fixup_cd.dat fixup_db.dat fixup_x.dat overlays start.elf start_cd.elf \
     start_db.elf start_x.elf"
 IMAGE_SIZE=$((3 * 1000 * 1000 * 1000)) # 1 GB too small - go with 3 GB default
-TARGET_ARCH=armv6
+TARGET_ARCH=armv7
+TARGET_CPUTYPE=cortex-a7
 
 UBOOT_PATH="/usr/local/share/u-boot/${RPI_UBOOT}"
 


### PR DESCRIPTION
Raspberry Pi 2 is using Cortex-a7 cpu, so it's a good idea to optimize system for that.
According to nbench, with this optimization system is 3% faster in integer aritmetic and 21% faster in floating-point.