### PR TITLE
Partial fixes for Raspberry Pi B build

### DIFF
--- a/board/RaspberryPi/README
+++ b/board/RaspberryPi/README
@@ -65,7 +65,7 @@ and UFS partitions containing the following files:
      RPI.DTS - Source version of FDT, for reference
      START.ELF - GPU firmware
      FIXUP.DAT - Used by start.elf to partition SDRAM between GPU and CPU
-     U-BOOT.IMG - Third stage: U-Boot loader
+     U-BOOT.BIN - Third stage: U-Boot loader
      UENV.TXT - Configuration file for U-Boot (empty by default)
      UBLDR - FreeBSD bootloader
 

--- a/board/RaspberryPi/setup.sh
+++ b/board/RaspberryPi/setup.sh
@@ -1,6 +1,6 @@
 KERNCONF=RPI-B
 RPI_UBOOT_PORT="u-boot-rpi"
-RPI_UBOOT_BIN="u-boot.img"
+RPI_UBOOT_BIN="u-boot.bin"
 RPI_FIRMWARE_SRC=/usr/local/share/u-boot/${RPI_UBOOT_PORT}
 RPI_GPU_MEM=32
 IMAGE_SIZE=$((1000 * 1000 * 1000)) # 1 GB default
@@ -62,7 +62,7 @@ raspberry_pi_populate_boot_partition ( ) {
     echo "device_tree_address=0x100" >> config.txt
 
     # Copy U-Boot to FAT partition, configure to chain-boot ubldr
-    echo "kernel=u-boot.img" >> config.txt
+    echo "kernel=u-boot.bin" >> config.txt
 
     # Install ubldr to FAT partition
     freebsd_ubldr_copy_ubldr .

--- a/config.sh.sample
+++ b/config.sh.sample
@@ -8,7 +8,7 @@
 # Note: Only board_setup is actually required, assuming /usr/src has
 # suitable FreeBSD sources.  Everything else below is optional.
 
-# REQUIRED: 
+# REQUIRED:
 # Uncomment one to choose the default configuration for your board.
 #
 # THIS MUST BE THE FIRST LINE IN YOUR CONFIG.SH FILE!
@@ -226,6 +226,8 @@
 # kernel builds.  Note that these are recorded in ${WORKDIR} when
 # Crochet runs a build; subsequent Crochet runs will skip the
 # corresponding build if the options are unchanged.
+# To allow quick rebuilds on changes, you may want to install ccache
+# and use FREEBSD_EXTRA_ARGS="MK_CCACHE_BUILD=yes".
 #
 # You can add your own options to any single build phase:
 #

--- a/lib/uboot.sh
+++ b/lib/uboot.sh
@@ -249,7 +249,7 @@ uboot_port_test ( ) {
 #  $2 name of script file
 #  $3 output file
 # 
-uboot_mkimage ( ) (
+uboot_mkimage ( ) {
     echo "Building and Installing U-Boot script"
     
     # location of input file
@@ -263,5 +263,4 @@ uboot_mkimage ( ) (
 
     # execute mkimage
     eval "$MKIMAGE -A arm -O FreeBSD -T script -C none -d $MKIMAGE_INPUT $MKIMAGE_OUTPUT" > ${WORKDIR}/_.mkimage.log
-)
-
+}


### PR DESCRIPTION
Image file name changed from u-boot.img to u-boot.bin in:

https://svnweb.freebsd.org/ports/head/sysutils/u-boot-master/Makefile?r1=453381&r2=454262
https://svnweb.freebsd.org/ports/head/sysutils/u-boot-rpi/Makefile?r1=429378&r2=454262

Also, document how to use ccache so I don't spend hours for attempts after the next build fix.

----------

P.S.: I couldn't get a full, successful build yet using [these small modifications to turn on ZFS](https://github.com/hughobrien/zfs-remote-mirror). It fails at basic C++ level, see below. I am using the releng/11.2 branch of the FreeBSD source code. Grateful for any help on this 

```
In file included from /mnt/freebsd-11.2/contrib/llvm/tools/lld/Common/Args.cpp:10:
In file included from /mnt/freebsd-11.2/contrib/llvm/tools/lld/include/lld/Common/Args.h:13:
In file included from /mnt/freebsd-11.2/contrib/llvm/tools/lld/include/lld/Common/LLVM.h:20:
In file included from /mnt/freebsd-11.2/contrib/llvm/include/llvm/ADT/Hashing.h:49:
In file included from /mnt/freebsd-11.2/contrib/llvm/include/llvm/Support/Host.h:17:
In file included from /mnt/freebsd-11.2/contrib/llvm/include/llvm/ADT/StringMap.h:17:
In file included from /mnt/freebsd-11.2/contrib/llvm/include/llvm/ADT/StringRef.h:13:
In file included from /mnt/freebsd-11.2/contrib/llvm/include/llvm/ADT/STLExtras.h:20:
In file included from /mnt/freebsd-11.2/contrib/llvm/include/llvm/ADT/Optional.h:22:
In file included from /mnt/freebsd-11.2/contrib/llvm/include/llvm/Support/type_traits.h:19:
In file included from /tmp/work/obj/arm.armv6/mnt/freebsd-11.2/tmp/usr/include/c++/v1/utility:202:
In file included from /tmp/work/obj/arm.armv6/mnt/freebsd-11.2/tmp/usr/include/c++/v1/cstring:61:
In file included from /tmp/work/obj/arm.armv6/mnt/freebsd-11.2/tmp/usr/include/c++/v1/string.h:61:
In file included from /tmp/work/obj/arm.armv6/mnt/freebsd-11.2/tmp/usr/include/string.h:45:
In file included from /mnt/freebsd-11.2/contrib/llvm/tools/lld/ELF/strings.h:14:
In file included from /mnt/freebsd-11.2/contrib/llvm/include/llvm/ADT/ArrayRef.h:15:
In file included from /mnt/freebsd-11.2/contrib/llvm/include/llvm/ADT/SmallVector.h:20:
In file included from /mnt/freebsd-11.2/contrib/llvm/include/llvm/Support/MathExtras.h:19:
In file included from /tmp/work/obj/arm.armv6/mnt/freebsd-11.2/tmp/usr/include/c++/v1/algorithm:643:
In file included from /tmp/work/obj/arm.armv6/mnt/freebsd-11.2/tmp/usr/include/c++/v1/memory:662:
/tmp/work/obj/arm.armv6/mnt/freebsd-11.2/tmp/usr/include/c++/v1/tuple:1361:22: error: C++ requires a type specifier for all declarations
pair<_T1, _T2>::pair(piecewise_construct_t,
                     ^
```