### PR TITLE
Pine64: image size increase to 3G

### DIFF
--- a/board/Pine64/setup.sh
+++ b/board/Pine64/setup.sh
@@ -2,7 +2,7 @@ KERNCONF=GENERIC
 PINE64_UBOOT_PORT="u-boot-pine64"
 PINE64_UBOOT_BIN="u-boot-sunxi-with-spl.bin"
 PINE64_UBOOT_PATH="/usr/local/share/u-boot/${PINE64_UBOOT_PORT}"
-IMAGE_SIZE=$((2000 * 1000 * 1000))
+IMAGE_SIZE=$((3000 * 1000 * 1000))
 TARGET_ARCH=aarch64
 TARGET=aarch64
 


### PR DESCRIPTION
Now "sudo ./crochet.sh -b Pine64" will get a 2.2G img.