### PR TITLE
NanoPi R4S: Add support for FriendlyElec Nano-Pi R4S (rk3399)

### DIFF
--- a/board/NanoPi-R4S/README
+++ b/board/NanoPi-R4S/README
@@ -1,0 +1,32 @@
+NanoPi R4S has been tested to work with FreeBSD 13
+
+============================================================
+
+What is a NanoPi R4S?
+---------------------
+
+The NanoPi R4S is a Rockchip RK3399 based 64-bit Quad-core
+Cortex-A57/A53 single board computer created by FriendlyElec.
+
+Details can be found at:
+   https://wiki.friendlyarm.com/wiki/index.php/NanoPi_R4S
+
+You boot it from a MicroSDHC card with the system image.
+
+Once you have the device working, you can expand it by
+connecting it to the Ethernet, adding USB peripherals (such
+as external disk drives or wireless network interfaces), or
+attach microcontrollers to GPIO connectors on the board.
+
+============================================================
+
+Booting the device
+------------------
+
+1. Insert a microSD card with this generated image. 
+
+2. Power on the board by connecting to a MicroUSB cable. 
+
+3. Connect using a USB to TTL Serial Cable
+
+   cu -l /dev/cuaU0 -s 1500000

--- a/board/NanoPi-R4S/overlay/boot/loader.conf
+++ b/board/NanoPi-R4S/overlay/boot/loader.conf
@@ -1,0 +1,6 @@
+# Multiple console (serial+efi gop) enabled
+boot_multicons="YES"
+boot_serial="YES"
+# Disable the beastie menu and color
+beastie_disable="YES"
+loader_color="NO"

--- a/board/NanoPi-R4S/overlay/etc/fstab
+++ b/board/NanoPi-R4S/overlay/etc/fstab
@@ -1,0 +1,5 @@
+/dev/mmcsd0s1	/boot/efi	msdosfs rw,noatime		0 0
+/dev/mmcsd0s2a	/		ufs	rw,noatime		1 1
+md		/tmp		mfs	rw,noatime,-s256m	0 0
+md		/var/log	mfs	rw,noatime,-s64m	0 0
+md		/var/tmp	mfs	rw,noatime,-s64m	0 0

--- a/board/NanoPi-R4S/overlay/etc/rc.conf
+++ b/board/NanoPi-R4S/overlay/etc/rc.conf
@@ -1,0 +1,12 @@
+hostname="nanopi-r4s"
+
+ifconfig_DEFAULT="DHCP"
+
+sendmail_enable="NONE"
+sendmail_submit_enable="NO"
+sendmail_outbound_enable="NO"
+sendmail_msp_queue_enable="NO"
+
+growfs_enable="YES"
+powerd_enable="YES"
+sshd_enable="YES"

--- a/board/NanoPi-R4S/setup.sh
+++ b/board/NanoPi-R4S/setup.sh
@@ -1,0 +1,40 @@
+# Setup for NanoPi-R4S
+
+KERNCONF=GENERIC
+
+TARGET=arm64
+TARGET_ARCH=aarch64
+
+UBOOT_DIR="u-boot-nanopi-r4s"
+UBOOT_PATH="/usr/local/share/u-boot/${UBOOT_DIR}"
+UBOOT_BIN="u-boot.itb"
+
+nanopi-r4s_check_uboot ( ) {
+	uboot_port_test ${UBOOT_DIR} ${UBOOT_BIN}
+}
+strategy_add $PHASE_CHECK nanopi-r4s_check_uboot
+
+#
+# NanoPI-R4S uses EFI, so the first partition will be a FAT partition.
+#
+nanopi-r4s_partition_image ( ) {
+	echo "Installing U-Boot on ${DISK_MD}"
+	dd if=${UBOOT_PATH}/idbloader.img of=/dev/${DISK_MD} conv=sync bs=512 seek=64
+	dd if=${UBOOT_PATH}/${UBOOT_BIN}  of=/dev/${DISK_MD} conv=sync bs=512 seek=16384
+
+	echo "Installing Partitions on ${DISK_MD}"
+	disk_partition_mbr
+	disk_fat_create 64m 16 1048576 -
+	disk_ufs_create
+}
+strategy_add $PHASE_PARTITION_LWW nanopi-r4s_partition_image
+
+# Build & install loader.efi.
+strategy_add $PHASE_BUILD_OTHER  freebsd_loader_efi_build
+strategy_add $PHASE_BOOT_INSTALL mkdir -p EFI/BOOT
+strategy_add $PHASE_BOOT_INSTALL freebsd_loader_efi_copy EFI/BOOT/bootaa64.efi
+
+# Puts the kernel on the FreeBSD UFS partition.
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL board_default_installkernel .
+# overlay/etc/fstab mounts the FAT partition at /boot/efi
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL mkdir -p boot/efi


### PR DESCRIPTION
This has been tested with FreeBSD 13.0-RELEASE and current. Board support is generally quite good and upstream u-boot supports it since 2021.07.

There also exists a 1GB/DDR3 variant of the board which upstream u-boot does not support (yet) but it looks like it is not sold anymore - so sorry for anyone that has bought the 1GB variant.

Bootlog is available at:
https://people.freebsd.org/~decke/nanopi-r4s/friendlyelec-nanopi-r4s-bootlog.txt