### PR TITLE
Increase RaspberryPi3 IMAGE_SIZE to 4GB

### DIFF
--- a/board/RaspberryPi3/setup.sh
+++ b/board/RaspberryPi3/setup.sh
@@ -15,7 +15,7 @@ RPI_FIRMWARE_FILES="bootcode.bin \
 if [ ${TARGET} == "aarch64" ]; then
     RPI_FIRMWARE_FILES="${RPI_FIRMWARE_FILES} armstub8.bin"
 fi
-IMAGE_SIZE=$((3 * 1000 * 1000 * 1000))
+IMAGE_SIZE=$((4 * 1000 * 1000 * 1000))
 
 # Not used - just in case someone wants to use a manual ubldr.  Obtained
 # from 'printenv' in boot0: kernel_addr_r=0x42000000


### PR DESCRIPTION
Using FreeBSD 15.0 source, the aarch64 build with 32-bit compat support does not fit in the freebsd ufs partition when the overall image/disk size is restricted to 3GB.