### PR TITLE
RaspberryPi4: Implement initial support

### DIFF
--- a/board/RaspberryPi4/README
+++ b/board/RaspberryPi4/README
@@ -1,0 +1,29 @@
+Raspberry Pi 4 is supported as of Oct 2023.
+
+============================================================
+
+What is a Raspberry Pi 4?
+--------------------
+
+The Raspberry Pi 4 is a quad-core 64-bit ARM single board computer.
+Details can be found at:
+
+   https://www.raspberrypi.com/products/raspberry-pi-4-model-b/
+
+You boot it from a MicroSDHC card with the system image.
+
+Once you have the Raspberry Pi 4 working, you can expand it by
+connecting it to Ethernet, adding USB peripherals (such as external
+disk drives) or attaching new hardware to the connectors on the board.
+
+============================================================
+
+How to boot the Raspberry Pi 4
+--------------------------------
+
+1. Connect the board to a HDMI display, network, and USB keyboard.
+   Network alone will work if you wish to boot headless.
+
+2. Insert a microSD card with this generated image.
+
+3. Power on the board by connecting it to a 5v power supply

--- a/board/RaspberryPi4/overlay/boot/loader.conf
+++ b/board/RaspberryPi4/overlay/boot/loader.conf
@@ -1,0 +1,1 @@
+geom_label_load="YES"		# File system labels (see glabel(8))

--- a/board/RaspberryPi4/overlay/boot/loader.rc
+++ b/board/RaspberryPi4/overlay/boot/loader.rc
@@ -1,0 +1,15 @@
+\ Load Forth utility functions
+include /boot/loader.4th
+
+\ Read and processes loader.conf variables
+start
+
+\ Tests for password -- executes autoboot first if a password was defined
+check-password
+
+\ Uncomment to enable boot menu
+\ include /boot/beastie.4th
+\ beastie-start
+
+\ Unless set otherwise, autoboot is automatic at this point
+

--- a/board/RaspberryPi4/overlay/etc/fstab
+++ b/board/RaspberryPi4/overlay/etc/fstab
@@ -1,0 +1,5 @@
+/dev/mmcsd0s1	/boot/efi	msdosfs rw,noatime	0 0
+/dev/mmcsd0s2a	/		ufs rw,noatime		1 1
+md		/tmp		mfs rw,noatime,-s50m	0 0
+md		/var/log	mfs rw,noatime,-s15m	0 0
+md		/var/tmp	mfs rw,noatime,-s12m	0 0

--- a/board/RaspberryPi4/overlay/etc/rc.conf
+++ b/board/RaspberryPi4/overlay/etc/rc.conf
@@ -1,0 +1,17 @@
+hostname="rpi4"
+ifconfig_ue0="DHCP"
+sshd_enable="YES"
+
+powerd_enable="YES"
+
+# Nice if you have a network, else annoying.
+#ntpd_enable="YES"
+ntpd_sync_on_start="YES"
+
+# Uncomment to disable common services (more memory)
+#cron_enable="NO"
+#syslogd_enable="NO"
+sendmail_enable="NONE"
+sendmail_submit_enable="NO"
+sendmail_outbound_enable="NO"
+sendmail_msp_queue_enable="NO"

--- a/board/RaspberryPi4/setup.sh
+++ b/board/RaspberryPi4/setup.sh
@@ -1,0 +1,81 @@
+TARGET_ARCH=aarch64
+TARGET=aarch64
+# ARMv7 32-bit build
+#TARGET=arm
+#TARGET_ARCH=armv7
+KERNCONF=GENERIC
+RPI4_UBOOT_PORT="u-boot-rpi4"
+RPI4_UBOOT_BIN="u-boot.bin"
+RPI4_UBOOT_PATH="${SHARE_PATH}/u-boot/${RPI4_UBOOT_PORT}"
+RPI_FIRMWARE_PORT="rpi-firmware"
+RPI_FIRMWARE_BIN="bootcode.bin"
+RPI_FIRMWARE_PATH="${SHARE_PATH}/${RPI_FIRMWARE_PORT}"
+RPI_FIRMWARE_FILES="bootcode.bin \
+    fixup4.dat fixup4cd.dat fixup4db.dat fixup4x.dat \
+    start4.elf start4cd.elf start4db.elf start4x.elf"
+if [ ${TARGET} == "aarch64" ]; then
+    RPI_FIRMWARE_FILES="${RPI_FIRMWARE_FILES} armstub8-gic.bin"
+fi
+IMAGE_SIZE=$((4 * 1000 * 1000 * 1000))
+
+# Not used - just in case someone wants to use a manual ubldr.  Obtained
+# from 'printenv' in boot0: kernel_addr_r=0x42000000
+#UBLDR_LOADADDR=0x42000000
+
+rpi4_check_uboot ( ) {
+    uboot_port_test ${RPI4_UBOOT_PORT} ${RPI4_UBOOT_BIN}
+}
+strategy_add $PHASE_CHECK rpi4_check_uboot
+
+rpi_check_firmware ( ) {
+    firmware_port_test ${RPI_FIRMWARE_PORT} ${RPI_FIRMWARE_BIN}
+}
+strategy_add $PHASE_CHECK rpi_check_firmware
+
+#
+# Rpi4 uses EFI, so the first partition will be a FAT partition.
+#
+rpi4_partition_image ( ) {
+    disk_partition_mbr
+    # Use FAT32. rpi4 does not support FAT16.
+    disk_fat_create 50m 32 -1 '' 1
+    disk_ufs_create
+}
+strategy_add $PHASE_PARTITION_LWW rpi4_partition_image
+
+raspberry_pi_populate_boot_partition ( ) {
+    mkdir -p EFI/BOOT
+    for file in ${RPI_FIRMWARE_FILES}; do
+        cp ${RPI_FIRMWARE_PATH}/${file} .
+    done
+    cp ${UBOOT_PATH}/u-boot.bin .
+    cp ${UBOOT_PATH}/README .
+
+    # Populate config.txt
+    if [ ${TARGET} == "aarch64" ]; then
+        cp ${RPI_FIRMWARE_PATH}/config_rpi4.txt config.txt
+    else
+        cp ${RPI_FIRMWARE_PATH}/config.txt config.txt
+        echo "dtoverlay=disable-bt" >> config.txt
+    fi
+
+    # Copy in overlays
+    cp -R ${RPI_FIRMWARE_PATH}/overlays .
+
+    # Populate DTB
+    cp ${RPI_FIRMWARE_PATH}/bcm2711-rpi-4-b.dtb .
+}
+strategy_add $PHASE_BOOT_INSTALL raspberry_pi_populate_boot_partition
+
+# Build & install loader.efi.
+strategy_add $PHASE_BUILD_OTHER freebsd_loader_efi_build
+if [ ${TARGET} == "aarch64" ]; then
+    strategy_add $PHASE_BOOT_INSTALL freebsd_loader_efi_copy EFI/BOOT/bootaa64.efi
+else
+    strategy_add $PHASE_BOOT_INSTALL freebsd_loader_efi_copy EFI/BOOT/bootarm.efi
+fi
+
+# Rpi4 puts the kernel on the FreeBSD UFS partition.
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL board_default_installkernel .
+# overlay/etc/fstab mounts the FAT partition at /boot/efi
+strategy_add $PHASE_FREEBSD_BOARD_INSTALL mkdir -p boot/efi

--- a/lib/disk.sh
+++ b/lib/disk.sh
@@ -285,6 +285,7 @@ disk_fat_partition ( ) {
 # $2: '12', '16', or '32' for FAT type (-1 or empty for default, which depends on $1)
 # $3: start block (-1 or empty for default of 63)
 # $4: label, empty for default of "BOOT"
+# $5: cluster size (-1 or empty for newfs_msdos default)
 disk_fat_create ( ) {
     local SIZE_ARG
     local SIZE_DISPLAY="n auto-sized"
@@ -292,6 +293,7 @@ disk_fat_create ( ) {
     local NEW_FAT_SLICE
     local NEW_FAT_DEVICE
     local NEW_FAT_SLICE_NUMBER
+    local CLUSTER_SIZE_ARG
 
     if [ -n "$1" -a \( "$1" != "-1" \) ]; then
 	SIZE_ARG="-s $1"
@@ -300,6 +302,10 @@ disk_fat_create ( ) {
 
     if [ -z "${FAT_LABEL}" ]; then
 	FAT_LABEL="BOOT"
+    fi
+
+    if [ -n "$5" -a \( "$1" != "-1" \) ]; then
+        CLUSTER_SIZE_ARG="-c $5"
     fi
 
     # start block
@@ -330,9 +336,9 @@ disk_fat_create ( ) {
     fi
 
     if [ "${FAT_LABEL}" = "-" ]; then
-        newfs_msdos -F ${_FAT_TYPE} ${NEW_FAT_DEVICE} >/dev/null
+        newfs_msdos ${CLUSTER_SIZE_ARG} -F ${_FAT_TYPE} ${NEW_FAT_DEVICE} >/dev/null
     else
-        newfs_msdos -L ${FAT_LABEL} -F ${_FAT_TYPE} ${NEW_FAT_DEVICE} >/dev/null
+        newfs_msdos ${CLUSTER_SIZE_ARG} -L ${FAT_LABEL} -F ${_FAT_TYPE} ${NEW_FAT_DEVICE} >/dev/null
     fi
 
     disk_created_new FAT ${NEW_FAT_SLICE}


### PR DESCRIPTION
Base support on the RaspberryPi3 crochet flow but use the correct firmware binaries and device-tree bindings.