### PR TITLE
fix: fix typos and shell assignment bug across scripts

### DIFF
--- a/board/RaspberryPiCM3L/setup.sh
+++ b/board/RaspberryPiCM3L/setup.sh
@@ -20,7 +20,7 @@ strategy_add $PHASE_CHECK rpi3_check_uboot
 
 rpi_cm3_check_firmware ( ) {
     if [ ! -d ${RPICM3_FIRMWARE_PATH} ]; then
-        echo "please install sysutils/${RPICM3_FIRMWARE_PORT} and re-run this script."
+        echo "Please install sysutils/${RPICM3_FIRMWARE_PORT} and re-run this script."
 	echo "You can do this with:"
 	echo "$ sudo pkg install sysutils/${RPICM3_FIRMWARE_PORT}"
 	echo "or by building the port:"

--- a/lib/uboot.sh
+++ b/lib/uboot.sh
@@ -19,7 +19,7 @@ _uboot_download_instructions ( ) (
 	local UBOOT_VERSION=`uboot_version_from_dir ${_UBOOT_SRC}`
 
 	if [ ${UBOOT_VERSION} = "unknown" ]; then
-	    UBOOT_VERSION = ${UBOOT_PATCH_VERSION}
+	    UBOOT_VERSION=${UBOOT_PATCH_VERSION}
 	fi
 
 	if [ ${UBOOT_VERSION} = "master" ]; then

--- a/option/NanoBSD/setup.sh
+++ b/option/NanoBSD/setup.sh
@@ -52,13 +52,13 @@ disk_ufs_create() {
 
     OSB_UFS_PARTITION=`gpart add -t freebsd-ufs ${NANO_OS_SIZE} ${NEW_UFS_SLICE} | sed -e 's/ .*//'` || exit 1
 
-    # CFG Paritition
+    # CFG Partition
     #CFG_UFS_PARTITION=`gpart add -t freebsd-ufs ${NANO_CFG_SIZE} -l cfg ${NEW_UFS_SLICE} | sed -e 's/ .*//'` || exit 1
     CFG_UFS_PARTITION=`gpart add -t freebsd-ufs -i 4 ${NANO_CFG_SIZE} ${NEW_UFS_SLICE} | sed -e 's/ .*//'` || exit 1
     CFG_UFS_DEVICE=/dev/${CFG_UFS_PARTITION}
     newfs ${CFG_UFS_DEVICE}
 
-    # DATA Paritition
+    # DATA Partition
     #DATA_UFS_PARTITION=`gpart add -t freebsd-ufs -l data ${NEW_UFS_SLICE} | sed -e 's/ .*//'` || exit 1
     DATA_UFS_PARTITION=`gpart add -t freebsd-ufs -i 5 ${NEW_UFS_SLICE} | sed -e 's/ .*//'` || exit 1
     DATA_UFS_DEVICE=/dev/${DATA_UFS_PARTITION}


### PR DESCRIPTION
## Summary

Fix 3 typos and 1 shell assignment bug across 3 files:

- `option/NanoBSD/setup.sh`: fix "Paritition" → "Partition" in partition label comments (2 instances)
- `board/RaspberryPiCM3L/setup.sh`: capitalize "please" → "Please" at start of user-facing message
- `lib/uboot.sh`: fix shell variable assignment — `UBOOT_VERSION = ${UBOOT_PATCH_VERSION}` has spaces around `=`, which in shell causes this to be interpreted as running a command `UBOOT_VERSION` with arguments `=` and the expanded value, rather than assigning the variable. Removed the spaces to make it a proper assignment.

The shell fix is a functional change; the others are comment/string only.